### PR TITLE
docs: add FUNDING.yml for GitHub Sponsors and thanks.dev

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: rsclarke
+thanks_dev: u/gh/rsclarke


### PR DESCRIPTION
Adds a FUNDING.yml to enable the GitHub Sponsor button and thanks.dev funding link on the repository.

- Add `.github/FUNDING.yml` with GitHub Sponsors and thanks.dev entries