### PR TITLE
fix(lint): enable all disabled linters and resolve issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ linters:
     - revive
     - rowserrcheck
     - sqlclosecheck
-    #- staticcheck
+    - staticcheck
     - thelper
     - unconvert
     - unparam
@@ -48,8 +48,6 @@ linters:
     - wastedassign
     - gosec
     - wrapcheck
-  disable:
-    - staticcheck
   settings:
     errorlint:
       errorf: true

--- a/main.go
+++ b/main.go
@@ -106,9 +106,9 @@ func (s *TaskfileServer) createTaskHandler(taskName string) mcp.ToolHandler {
 		var result strings.Builder
 
 		if taskErr != nil {
-			result.WriteString(fmt.Sprintf("Task '%s' failed with error: %v\n", taskName, taskErr))
+			fmt.Fprintf(&result, "Task '%s' failed with error: %v\n", taskName, taskErr)
 		} else {
-			result.WriteString(fmt.Sprintf("Task '%s' completed successfully.\n", taskName))
+			fmt.Fprintf(&result, "Task '%s' completed successfully.\n", taskName)
 		}
 
 		if stdoutStr != "" {


### PR DESCRIPTION
Enable all seven previously disabled golangci-lint linters (errchkjson, godot, modernize, nilerr, perfsprint, revive, staticcheck) and fix the violations they surface. This removes the disable list entirely so all configured linters are active.

- Handle `json.Marshal` error return instead of discarding it (errchkjson)
- Add trailing periods to all exported comments (godot)
- Replace map k/v loops with `maps.Insert` (modernize)
- Refactor task execution error handling to avoid returning nil when err is set (nilerr)
- Use string concatenation and `errors.New` over `fmt.Sprintf`/`fmt.Errorf` (perfsprint)
- Add package comment for main package (revive)
- Use `fmt.Fprintf` instead of `WriteString(fmt.Sprintf(...))` (staticcheck)