### PR TITLE
refactor: introduce rootState and multi-root support in TaskfileServer

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,13 @@ import (
 	"io/fs"
 	"log"
 	"maps"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -54,13 +57,109 @@ func countWildcards(taskName string) int {
 	return strings.Count(taskName, "*")
 }
 
-// TaskfileServer represents our MCP server for Taskfile.yml.
-type TaskfileServer struct {
+// rootState holds the per-root task executor state.
+type rootState struct {
 	executor        *task.Executor
 	taskfile        *ast.Taskfile
 	workdir         string
+	registeredTools []string
+	watcher         *fsnotify.Watcher
+}
+
+// TaskfileServer represents our MCP server for Taskfile.yml.
+type TaskfileServer struct {
+	roots           map[string]*rootState
 	mcpServer       *mcp.Server
 	registeredTools map[string]mcp.Tool
+	mu              sync.Mutex
+}
+
+// dirToURI converts an absolute directory path to a file:// URI.
+func dirToURI(dir string) string {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		abs = dir
+	}
+	return "file://" + filepath.ToSlash(abs)
+}
+
+// uriToDir converts a file:// URI back to a local directory path.
+func uriToDir(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", fmt.Errorf("invalid URI %q: %w", uri, err)
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("unsupported URI scheme %q (only file:// is supported)", u.Scheme)
+	}
+	return filepath.FromSlash(u.Path), nil
+}
+
+// validRootPrefixChars matches characters NOT allowed in a root prefix.
+var validRootPrefixChars = regexp.MustCompile(`[^a-zA-Z0-9_.\-]`)
+
+// sanitizeRootPrefix converts a root name or directory basename into a valid
+// MCP tool name prefix component.
+func sanitizeRootPrefix(name string) string {
+	s := validRootPrefixChars.ReplaceAllString(name, "_")
+	s = strings.Trim(s, "_")
+	if s == "" {
+		return "root"
+	}
+	return s
+}
+
+// loadRoot creates a new rootState by loading the Taskfile from the given directory.
+func loadRoot(dir string) (*rootState, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	executor := task.NewExecutor(
+		task.WithDir(abs),
+		task.WithSilent(true),
+	)
+
+	if err := executor.Setup(); err != nil {
+		return nil, fmt.Errorf("failed to setup task executor for %s: %w", abs, err)
+	}
+
+	return &rootState{
+		executor: executor,
+		taskfile: executor.Taskfile,
+		workdir:  abs,
+	}, nil
+}
+
+// unloadRoot removes and cleans up the root with the given URI.
+func (s *TaskfileServer) unloadRoot(uri string) {
+	root, ok := s.roots[uri]
+	if !ok {
+		return
+	}
+	if root.watcher != nil {
+		_ = root.watcher.Close()
+	}
+	delete(s.roots, uri)
+}
+
+// rootPrefix returns the tool name prefix for a root. When there is only one
+// root the prefix is empty; with multiple roots it is derived from the root
+// directory's basename.
+func (s *TaskfileServer) rootPrefix(root *rootState) string {
+	if len(s.roots) <= 1 {
+		return ""
+	}
+	return sanitizeRootPrefix(filepath.Base(root.workdir))
+}
+
+// prefixedToolName returns the tool name with an optional root prefix.
+func prefixedToolName(prefix, toolName string) string {
+	if prefix == "" {
+		return toolName
+	}
+	return prefix + "_" + toolName
 }
 
 // NewTaskfileServer creates a new Taskfile MCP server.
@@ -70,27 +169,21 @@ func NewTaskfileServer() (*TaskfileServer, error) {
 		return nil, fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	// Create a task executor
-	executor := task.NewExecutor(
-		task.WithDir(workdir),
-		task.WithSilent(true),
-	)
-
-	// Setup the executor (this loads the Taskfile)
-	if err := executor.Setup(); err != nil {
-		return nil, fmt.Errorf("failed to setup task executor: %w", err)
+	root, err := loadRoot(workdir)
+	if err != nil {
+		return nil, err
 	}
 
+	uri := dirToURI(workdir)
+
 	return &TaskfileServer{
-		executor: executor,
-		taskfile: executor.Taskfile,
-		workdir:  workdir,
+		roots: map[string]*rootState{uri: root},
 	}, nil
 }
 
 // createTaskHandler creates a handler function for a specific task.
 // For wildcard tasks, it reconstructs the full task name from the MATCH argument.
-func (s *TaskfileServer) createTaskHandler(taskName string) mcp.ToolHandler {
+func createTaskHandler(root *rootState, taskName string) mcp.ToolHandler {
 	wildcard := isWildcardTask(taskName)
 	wildcardCount := countWildcards(taskName)
 
@@ -144,7 +237,7 @@ func (s *TaskfileServer) createTaskHandler(taskName string) mcp.ToolHandler {
 
 		// Create a new executor with output capture for this execution
 		executor := task.NewExecutor(
-			task.WithDir(s.workdir),
+			task.WithDir(root.workdir),
 			task.WithStdout(&stdout),
 			task.WithStderr(&stderr),
 			task.WithSilent(true),
@@ -197,15 +290,16 @@ func (s *TaskfileServer) createTaskHandler(taskName string) mcp.ToolHandler {
 
 // createToolForTask creates an MCP tool definition for a given task.
 // The tool name is sanitized for MCP compatibility; the description
-// references the original Taskfile task name for clarity.
-func (s *TaskfileServer) createToolForTask(taskName string, taskDef *ast.Task) *mcp.Tool {
-	toolName := sanitizeToolName(taskName)
+// references the original Taskfile task name for clarity. The prefix
+// parameter is used in multi-root mode to namespace tool names.
+func createToolForTask(root *rootState, prefix, taskName string, taskDef *ast.Task) *mcp.Tool {
+	toolName := prefixedToolName(prefix, sanitizeToolName(taskName))
 
 	description := taskDef.Desc
 	if description == "" {
 		description = "Execute task: " + taskName
 	}
-	if toolName != taskName {
+	if sanitizeToolName(taskName) != taskName {
 		description += fmt.Sprintf(" (task: %s)", taskName)
 	}
 
@@ -213,8 +307,8 @@ func (s *TaskfileServer) createToolForTask(taskName string, taskDef *ast.Task) *
 	allVars := make(map[string]ast.Var)
 
 	// Add global variables first
-	if s.taskfile.Vars != nil && s.taskfile.Vars.Len() > 0 {
-		maps.Insert(allVars, s.taskfile.Vars.All())
+	if root.taskfile.Vars != nil && root.taskfile.Vars.Len() > 0 {
+		maps.Insert(allVars, root.taskfile.Vars.All())
 	}
 
 	// Add task-specific variables (these override global ones)
@@ -271,24 +365,41 @@ func (s *TaskfileServer) createToolForTask(taskName string, taskDef *ast.Task) *
 	}
 }
 
-// buildToolSet discovers all tasks and returns tool definitions and handlers
-// without registering them on a server.
+// buildToolSet discovers all tasks across all roots and returns tool definitions
+// and handlers without registering them on a server. It also populates each
+// root's registeredTools list.
 func (s *TaskfileServer) buildToolSet() (map[string]mcp.Tool, map[string]mcp.ToolHandler, error) {
-	if s.taskfile.Tasks == nil {
-		return nil, nil, errors.New("no tasks found in Taskfile")
-	}
-
 	tools := make(map[string]mcp.Tool)
 	handlers := make(map[string]mcp.ToolHandler)
 
-	for taskName, taskDef := range s.taskfile.Tasks.All(nil) {
-		if taskDef.Internal {
+	for _, root := range s.roots {
+		root.registeredTools = nil
+	}
+
+	for _, root := range s.roots {
+		if root.taskfile.Tasks == nil {
 			continue
 		}
 
-		tool := s.createToolForTask(taskName, taskDef)
-		tools[tool.Name] = *tool
-		handlers[tool.Name] = s.createTaskHandler(taskName)
+		prefix := s.rootPrefix(root)
+
+		for taskName, taskDef := range root.taskfile.Tasks.All(nil) {
+			if taskDef.Internal {
+				continue
+			}
+
+			tool := createToolForTask(root, prefix, taskName, taskDef)
+			if _, exists := tools[tool.Name]; exists {
+				return nil, nil, fmt.Errorf("tool name collision: %q", tool.Name)
+			}
+			tools[tool.Name] = *tool
+			handlers[tool.Name] = createTaskHandler(root, taskName)
+			root.registeredTools = append(root.registeredTools, tool.Name)
+		}
+	}
+
+	if len(tools) == 0 {
+		return nil, nil, errors.New("no tasks found in any Taskfile")
 	}
 
 	return tools, handlers, nil
@@ -351,34 +462,60 @@ func isTaskfile(path string) bool {
 	return slices.Contains(taskfile.DefaultTaskfiles, filepath.Base(path))
 }
 
-// loadAndRegisterTools re-creates the task executor from the working
-// directory and syncs the MCP tool set to match the current Taskfile
-// definitions.
-func (s *TaskfileServer) loadAndRegisterTools() error {
+// reloadRoot re-creates the task executor for a given root URI and syncs
+// the global MCP tool set.
+func (s *TaskfileServer) reloadRoot(uri string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	root, ok := s.roots[uri]
+	if !ok {
+		return fmt.Errorf("unknown root %q", uri)
+	}
+
 	executor := task.NewExecutor(
-		task.WithDir(s.workdir),
+		task.WithDir(root.workdir),
 		task.WithSilent(true),
 	)
 	if err := executor.Setup(); err != nil {
-		return fmt.Errorf("failed to setup task executor: %w", err)
+		return fmt.Errorf("failed to setup task executor for %s: %w", root.workdir, err)
 	}
-	s.executor = executor
-	s.taskfile = executor.Taskfile
+	root.executor = executor
+	root.taskfile = executor.Taskfile
 	return s.syncTools()
 }
 
-// watchTaskfiles watches the working directory tree for Taskfile changes
-// and reloads tools when a relevant file is modified. It blocks until the
-// context is cancelled.
-func (s *TaskfileServer) watchTaskfiles(ctx context.Context) error {
+// loadAndRegisterTools re-creates the task executor from the single root
+// working directory and syncs the MCP tool set. This is a convenience
+// wrapper for the single-root case.
+func (s *TaskfileServer) loadAndRegisterTools() error {
+	for uri := range s.roots {
+		return s.reloadRoot(uri)
+	}
+	return errors.New("no roots configured")
+}
+
+// watchRootTaskfiles watches a single root's directory tree for Taskfile
+// changes and reloads tools when a relevant file is modified.
+func (s *TaskfileServer) watchRootTaskfiles(ctx context.Context, uri string, root *rootState) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("failed to create file watcher: %w", err)
 	}
-	defer func() { _ = watcher.Close() }()
 
-	// Recursively add all directories under workdir.
-	err = filepath.WalkDir(s.workdir, func(path string, d fs.DirEntry, err error) error {
+	s.mu.Lock()
+	root.watcher = watcher
+	s.mu.Unlock()
+
+	defer func() {
+		_ = watcher.Close()
+		s.mu.Lock()
+		root.watcher = nil
+		s.mu.Unlock()
+	}()
+
+	// Recursively add all directories under the root's workdir.
+	err = filepath.WalkDir(root.workdir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -422,8 +559,8 @@ func (s *TaskfileServer) watchTaskfiles(ctx context.Context) error {
 				timer.Stop()
 			}
 			timer = time.AfterFunc(debounce, func() {
-				if err := s.loadAndRegisterTools(); err != nil {
-					log.Printf("failed to reload tools: %v", err)
+				if err := s.reloadRoot(uri); err != nil {
+					log.Printf("failed to reload tools for root %s: %v", uri, err)
 				}
 			})
 		case err, ok := <-watcher.Errors:
@@ -433,6 +570,25 @@ func (s *TaskfileServer) watchTaskfiles(ctx context.Context) error {
 			log.Printf("file watcher error: %v", err)
 		}
 	}
+}
+
+// watchTaskfiles starts file watchers for all roots and blocks until the
+// context is cancelled.
+func (s *TaskfileServer) watchTaskfiles(ctx context.Context) error {
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for uri, root := range s.roots {
+		wg.Go(func() {
+			if err := s.watchRootTaskfiles(ctx, uri, root); err != nil {
+				errOnce.Do(func() { firstErr = err })
+			}
+		})
+	}
+
+	wg.Wait()
+	return firstErr
 }
 
 func run() error {

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/taskfile/ast"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -25,19 +24,27 @@ func loadServerFromFixture(t *testing.T, name string) *TaskfileServer {
 	_, filename, _, _ := runtime.Caller(0)
 	dir := filepath.Join(filepath.Dir(filename), "testdata", name)
 
-	executor := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithSilent(true),
-	)
-
-	if err := executor.Setup(); err != nil {
-		t.Fatalf("failed to setup executor for fixture %q: %v", name, err)
+	root, err := loadRoot(dir)
+	if err != nil {
+		t.Fatalf("failed to load root for fixture %q: %v", name, err)
 	}
 
+	uri := dirToURI(dir)
 	return &TaskfileServer{
-		taskfile: executor.Taskfile,
-		workdir:  dir,
+		roots: map[string]*rootState{uri: root},
 	}
+}
+
+// onlyRoot returns the single rootState from a server, or fails the test.
+func onlyRoot(t *testing.T, s *TaskfileServer) *rootState {
+	t.Helper()
+	if len(s.roots) != 1 {
+		t.Fatalf("expected 1 root, got %d", len(s.roots))
+	}
+	for _, root := range s.roots {
+		return root
+	}
+	return nil
 }
 
 // newTestServer creates a TaskfileServer from a fixture with a real *mcp.Server attached.
@@ -70,9 +77,10 @@ func schemaProperties(t *testing.T, tool *mcp.Tool) map[string]any {
 
 func TestCreateToolForTask_Basic(t *testing.T) {
 	s := loadServerFromFixture(t, "basic")
+	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, s.taskfile, "greet")
-	tool := s.createToolForTask("greet", taskDef)
+	taskDef := lookupTask(t, root.taskfile, "greet")
+	tool := createToolForTask(root, "", "greet", taskDef)
 
 	if tool.Name != "greet" {
 		t.Errorf("Name = %q, want %q", tool.Name, "greet")
@@ -89,9 +97,10 @@ func TestCreateToolForTask_Basic(t *testing.T) {
 
 func TestCreateToolForTask_NoDescription(t *testing.T) {
 	s := loadServerFromFixture(t, "no-desc")
+	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, s.taskfile, "build")
-	tool := s.createToolForTask("build", taskDef)
+	taskDef := lookupTask(t, root.taskfile, "build")
+	tool := createToolForTask(root, "", "build", taskDef)
 
 	want := "Execute task: build"
 	if tool.Description != want {
@@ -101,9 +110,10 @@ func TestCreateToolForTask_NoDescription(t *testing.T) {
 
 func TestCreateToolForTask_TaskVars(t *testing.T) {
 	s := loadServerFromFixture(t, "task-vars")
+	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, s.taskfile, "deploy")
-	tool := s.createToolForTask("deploy", taskDef)
+	taskDef := lookupTask(t, root.taskfile, "deploy")
+	tool := createToolForTask(root, "", "deploy", taskDef)
 
 	props := schemaProperties(t, tool)
 	if len(props) != 2 {
@@ -125,9 +135,10 @@ func TestCreateToolForTask_TaskVars(t *testing.T) {
 
 func TestCreateToolForTask_GlobalVars(t *testing.T) {
 	s := loadServerFromFixture(t, "global-vars")
+	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, s.taskfile, "info")
-	tool := s.createToolForTask("info", taskDef)
+	taskDef := lookupTask(t, root.taskfile, "info")
+	tool := createToolForTask(root, "", "info", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["APP_NAME"]
@@ -144,9 +155,10 @@ func TestCreateToolForTask_GlobalVars(t *testing.T) {
 
 func TestCreateToolForTask_OverrideVars(t *testing.T) {
 	s := loadServerFromFixture(t, "override-vars")
+	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, s.taskfile, "deploy")
-	tool := s.createToolForTask("deploy", taskDef)
+	taskDef := lookupTask(t, root.taskfile, "deploy")
+	tool := createToolForTask(root, "", "deploy", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["ENV"]
@@ -223,6 +235,7 @@ func TestSanitizeToolName(t *testing.T) {
 
 func TestCreateToolForTask_Namespaced(t *testing.T) {
 	s := loadServerFromFixture(t, "namespaced")
+	root := onlyRoot(t, s)
 
 	tests := []struct {
 		taskName string
@@ -236,8 +249,8 @@ func TestCreateToolForTask_Namespaced(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.taskName, func(t *testing.T) {
-			taskDef := lookupTask(t, s.taskfile, tt.taskName)
-			tool := s.createToolForTask(tt.taskName, taskDef)
+			taskDef := lookupTask(t, root.taskfile, tt.taskName)
+			tool := createToolForTask(root, "", tt.taskName, taskDef)
 
 			if tool.Name != tt.wantTool {
 				t.Errorf("Name = %q, want %q", tool.Name, tt.wantTool)
@@ -251,10 +264,11 @@ func TestCreateToolForTask_Namespaced(t *testing.T) {
 
 func TestCreateToolForTask_Wildcard(t *testing.T) {
 	s := loadServerFromFixture(t, "wildcard")
+	root := onlyRoot(t, s)
 
 	t.Run("single wildcard", func(t *testing.T) {
-		taskDef := lookupTask(t, s.taskfile, "start:*")
-		tool := s.createToolForTask("start:*", taskDef)
+		taskDef := lookupTask(t, root.taskfile, "start:*")
+		tool := createToolForTask(root, "", "start:*", taskDef)
 
 		if tool.Name != "start" {
 			t.Errorf("Name = %q, want %q", tool.Name, "start")
@@ -272,8 +286,8 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 	})
 
 	t.Run("double wildcard", func(t *testing.T) {
-		taskDef := lookupTask(t, s.taskfile, "deploy:*:*")
-		tool := s.createToolForTask("deploy:*:*", taskDef)
+		taskDef := lookupTask(t, root.taskfile, "deploy:*:*")
+		tool := createToolForTask(root, "", "deploy:*:*", taskDef)
 
 		if tool.Name != "deploy" {
 			t.Errorf("Name = %q, want %q", tool.Name, "deploy")
@@ -295,9 +309,10 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 
 func TestCreateToolForTask_LeadingDot(t *testing.T) {
 	s := loadServerFromFixture(t, "leading-dot")
+	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, s.taskfile, "uv:.venv")
-	tool := s.createToolForTask("uv:.venv", taskDef)
+	taskDef := lookupTask(t, root.taskfile, "uv:.venv")
+	tool := createToolForTask(root, "", "uv:.venv", taskDef)
 
 	if tool.Name != "uv_.venv" {
 		t.Errorf("Name = %q, want %q", tool.Name, "uv_.venv")
@@ -473,6 +488,116 @@ func TestIsTaskfile(t *testing.T) {
 	}
 }
 
+func TestDirToURI(t *testing.T) {
+	uri := dirToURI("/some/path")
+	if uri != "file:///some/path" {
+		t.Errorf("dirToURI(%q) = %q, want %q", "/some/path", uri, "file:///some/path")
+	}
+}
+
+func TestURIToDir(t *testing.T) {
+	dir, err := uriToDir("file:///some/path")
+	if err != nil {
+		t.Fatalf("uriToDir failed: %v", err)
+	}
+	if dir != "/some/path" {
+		t.Errorf("uriToDir = %q, want %q", dir, "/some/path")
+	}
+
+	_, err = uriToDir("https://example.com")
+	if err == nil {
+		t.Error("expected error for non-file URI")
+	}
+}
+
+func TestSanitizeRootPrefix(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"myproject", "myproject"},
+		{"my project", "my_project"},
+		{"my/project", "my_project"},
+		{"___", "root"},
+		{"", "root"},
+		{"a-b.c_d", "a-b.c_d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeRootPrefix(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeRootPrefix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnloadRoot(t *testing.T) {
+	s := newTestServer(t, "basic")
+	if err := s.syncTools(); err != nil {
+		t.Fatalf("syncTools failed: %v", err)
+	}
+	if len(s.roots) != 1 {
+		t.Fatalf("expected 1 root, got %d", len(s.roots))
+	}
+
+	var uri string
+	for u := range s.roots {
+		uri = u
+	}
+
+	s.unloadRoot(uri)
+	if len(s.roots) != 0 {
+		t.Errorf("expected 0 roots after unload, got %d", len(s.roots))
+	}
+
+	// Unloading a non-existent root should be a no-op.
+	s.unloadRoot("file:///nonexistent")
+}
+
+func TestMultiRoot_Prefixing(t *testing.T) {
+	s := loadServerFromFixture(t, "basic")
+	s.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
+	s.registeredTools = make(map[string]mcp.Tool)
+
+	// Load a second root from a different fixture.
+	_, filename, _, _ := runtime.Caller(0)
+	dir2 := filepath.Join(filepath.Dir(filename), "testdata", "no-desc")
+	root2, err := loadRoot(dir2)
+	if err != nil {
+		t.Fatalf("loadRoot: %v", err)
+	}
+	s.roots[dirToURI(dir2)] = root2
+
+	if err := s.syncTools(); err != nil {
+		t.Fatalf("syncTools failed: %v", err)
+	}
+
+	// With 2 roots, tools should be prefixed.
+	if len(s.registeredTools) < 2 {
+		t.Fatalf("expected at least 2 tools, got %d: %v", len(s.registeredTools), toolNames(s.registeredTools))
+	}
+
+	// Verify that no tool name is unprefixed "greet" or "build".
+	for name := range s.registeredTools {
+		if name == "greet" || name == "build" {
+			t.Errorf("expected prefixed tool name, got %q", name)
+		}
+	}
+}
+
+func TestMultiRoot_SingleRoot_NoPrefix(t *testing.T) {
+	s := newTestServer(t, "basic")
+	if err := s.syncTools(); err != nil {
+		t.Fatalf("syncTools failed: %v", err)
+	}
+
+	// Single root: no prefix.
+	if _, ok := s.registeredTools["greet"]; !ok {
+		t.Errorf("expected unprefixed tool %q, got: %v", "greet", toolNames(s.registeredTools))
+	}
+}
+
 func TestLoadAndRegisterTools(t *testing.T) {
 	s := newTestServer(t, "basic")
 
@@ -496,21 +621,7 @@ func TestWatchTaskfiles_ReloadsOnChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build a server pointing at the temp dir.
-	executor := task.NewExecutor(task.WithDir(dir), task.WithSilent(true))
-	if err := executor.Setup(); err != nil {
-		t.Fatalf("executor setup: %v", err)
-	}
-	s := &TaskfileServer{
-		executor:        executor,
-		taskfile:        executor.Taskfile,
-		workdir:         dir,
-		mcpServer:       mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil),
-		registeredTools: make(map[string]mcp.Tool),
-	}
-	if err := s.syncTools(); err != nil {
-		t.Fatalf("initial syncTools: %v", err)
-	}
+	s := newServerForDir(t, dir)
 	if _, ok := s.registeredTools["hello"]; !ok {
 		t.Fatal("expected initial tool 'hello'")
 	}
@@ -554,20 +665,7 @@ func TestWatchTaskfiles_IgnoresNonTaskfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	executor := task.NewExecutor(task.WithDir(dir), task.WithSilent(true))
-	if err := executor.Setup(); err != nil {
-		t.Fatalf("executor setup: %v", err)
-	}
-	s := &TaskfileServer{
-		executor:        executor,
-		taskfile:        executor.Taskfile,
-		workdir:         dir,
-		mcpServer:       mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil),
-		registeredTools: make(map[string]mcp.Tool),
-	}
-	if err := s.syncTools(); err != nil {
-		t.Fatalf("initial syncTools: %v", err)
-	}
+	s := newServerForDir(t, dir)
 
 	ctx := t.Context()
 
@@ -597,17 +695,7 @@ func TestWatchTaskfiles_CancelStops(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	executor := task.NewExecutor(task.WithDir(dir), task.WithSilent(true))
-	if err := executor.Setup(); err != nil {
-		t.Fatalf("executor setup: %v", err)
-	}
-	s := &TaskfileServer{
-		executor:        executor,
-		taskfile:        executor.Taskfile,
-		workdir:         dir,
-		mcpServer:       mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil),
-		registeredTools: make(map[string]mcp.Tool),
-	}
+	s := newServerForDir(t, dir)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -637,14 +725,20 @@ func newTempServer(t *testing.T, taskfileContent []byte) *TaskfileServer {
 	if err := os.WriteFile(filepath.Join(dir, "Taskfile.yml"), taskfileContent, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	executor := task.NewExecutor(task.WithDir(dir), task.WithSilent(true))
-	if err := executor.Setup(); err != nil {
-		t.Fatalf("executor setup: %v", err)
+	return newServerForDir(t, dir)
+}
+
+// newServerForDir creates a TaskfileServer backed by a given directory,
+// with a real *mcp.Server and initial syncTools.
+func newServerForDir(t *testing.T, dir string) *TaskfileServer {
+	t.Helper()
+	root, err := loadRoot(dir)
+	if err != nil {
+		t.Fatalf("loadRoot: %v", err)
 	}
+	uri := dirToURI(dir)
 	s := &TaskfileServer{
-		executor:        executor,
-		taskfile:        executor.Taskfile,
-		workdir:         dir,
+		roots:           map[string]*rootState{uri: root},
 		mcpServer:       mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil),
 		registeredTools: make(map[string]mcp.Tool),
 	}
@@ -700,7 +794,7 @@ func TestLoadAndRegisterTools_RemovesTask(t *testing.T) {
 
 	// Remove the "goodbye" task from the Taskfile.
 	updated := []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n")
-	if err := os.WriteFile(filepath.Join(s.workdir, "Taskfile.yml"), updated, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).workdir, "Taskfile.yml"), updated, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -727,7 +821,7 @@ func TestLoadAndRegisterTools_UpdatesChangedTask(t *testing.T) {
 
 	// Update the task description.
 	updated := []byte("version: '3'\ntasks:\n  greet:\n    desc: Say hi there\n    cmds:\n      - echo hi there\n")
-	if err := os.WriteFile(filepath.Join(s.workdir, "Taskfile.yml"), updated, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).workdir, "Taskfile.yml"), updated, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -747,6 +841,7 @@ func TestLoadAndRegisterTools_UpdatesChangedTask(t *testing.T) {
 func TestWatchTaskfiles_DebounceCoalesces(t *testing.T) {
 	initial := []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n")
 	s := newTempServer(t, initial)
+	root := onlyRoot(t, s)
 
 	// Count reloads by tracking description changes.
 	// We'll write multiple rapid updates and verify the final state
@@ -762,7 +857,7 @@ func TestWatchTaskfiles_DebounceCoalesces(t *testing.T) {
 	// Fire multiple rapid writes within the debounce window (200ms).
 	for i := range 5 {
 		content := fmt.Appendf(nil, "version: '3'\ntasks:\n  hello:\n    desc: Attempt %d\n    cmds:\n      - echo hello\n", i)
-		if err := os.WriteFile(filepath.Join(s.workdir, "Taskfile.yml"), content, 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(root.workdir, "Taskfile.yml"), content, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -793,20 +888,7 @@ func TestWatchTaskfiles_NewSubdirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	executor := task.NewExecutor(task.WithDir(dir), task.WithSilent(true))
-	if err := executor.Setup(); err != nil {
-		t.Fatalf("executor setup: %v", err)
-	}
-	s := &TaskfileServer{
-		executor:        executor,
-		taskfile:        executor.Taskfile,
-		workdir:         dir,
-		mcpServer:       mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil),
-		registeredTools: make(map[string]mcp.Tool),
-	}
-	if err := s.syncTools(); err != nil {
-		t.Fatalf("initial syncTools: %v", err)
-	}
+	s := newServerForDir(t, dir)
 
 	ctx := t.Context()
 


### PR DESCRIPTION
Refactor TaskfileServer from single-root to multi-root architecture in preparation for MCP Roots capability support (#15). The single `executor`/`taskfile`/`workdir` fields are replaced with a per-root `rootState` struct, enabling the server to manage multiple Taskfile roots independently.

- Introduce `rootState` struct holding executor, taskfile, workdir, registered tool names, and fsnotify watcher
- Replace single-root fields with `map[string]*rootState` keyed by root URI
- Extract `loadRoot(dir)` and `unloadRoot(uri)` lifecycle methods
- Add `dirToURI`/`uriToDir` helpers for file:// URI conversion
- Add `sanitizeRootPrefix` for multi-root tool name prefixing (prefix applied when >1 root; single root uses no prefix)
- Make `createTaskHandler` and `createToolForTask` root-aware free functions
- `buildToolSet` iterates all roots with per-root prefix computation and collision detection
- `watchTaskfiles` delegates to per-root `watchRootTaskfiles` goroutines
- Add `sync.Mutex` for concurrent watcher safety
- Consolidate test helpers into `newServerForDir` and `onlyRoot`
- Add tests for URI helpers, prefix sanitization, unloadRoot, and multi-root prefixing behavior

Closes #19