### PR TITLE
feat: support build-time server name and version via ldflags

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,15 @@ tasks:
     cmds:
       - go test ./...
 
+  build:
+    desc: Build the server binary
+    vars:
+      VERSION:
+        sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"
+      LDFLAGS: -s -w -X main.serverVersion={{.VERSION}}
+    cmds:
+      - go build -ldflags '{{.LDFLAGS}}' -o mcp-taskfile-server .
+
   ci:
     desc: Run lint and test checks
     cmds:

--- a/main.go
+++ b/main.go
@@ -27,6 +27,12 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// Build-time variables set via -ldflags.
+var (
+	serverName    = "mcp-taskfile-server"
+	serverVersion = "dev"
+)
+
 // sanitizeToolName converts a Taskfile task name into a valid MCP tool name.
 // It replaces colons with underscores and strips wildcard (*) segments.
 // The returned name conforms to the MCP spec: [a-zA-Z0-9_.-]{1,128}.
@@ -726,8 +732,8 @@ func run() error {
 	// Create MCP server with lifecycle handlers
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
-			Name:    "taskfile-mcp-server",
-			Version: "1.0.0",
+			Name:    serverName,
+			Version: serverVersion,
 		},
 		&mcp.ServerOptions{
 			InitializedHandler:      taskfileServer.handleInitialized,


### PR DESCRIPTION
Adds build-time configurable `serverName` and `serverVersion` variables to the MCP server implementation, settable via `-ldflags`. This allows the server identity and version to be injected at compile time rather than being hardcoded.

- Add `serverName` and `serverVersion` package-level variables with sensible defaults (`mcp-taskfile-server` and `dev`)
- Use these variables in the `mcp.Implementation` struct instead of hardcoded values
- Add a `build` task to `Taskfile.yml` that derives the version from `git describe --tags --always --dirty` and injects it via `-ldflags`