### PR TITLE
fix: use background context for file watchers to prevent premature cancellation

### DIFF
--- a/main.go
+++ b/main.go
@@ -595,13 +595,16 @@ func isMethodNotFound(err error) bool {
 }
 
 // restartWatchers cancels any running file watchers and starts new ones
-// for all current roots. The provided ctx should be the long-lived server
-// context from which a child context is derived.
+// for all current roots. The provided ctx is intentionally detached via
+// context.WithoutCancel because callers pass request-scoped contexts
+// that are cancelled after the handler returns.
 func (s *TaskfileServer) restartWatchers(ctx context.Context) {
 	if s.watchCancel != nil {
 		s.watchCancel()
 	}
-	watchCtx, cancel := context.WithCancel(ctx) //nolint:gosec // cancel is stored in s.watchCancel and called on next restart or shutdown
+	// Detach from the caller's request-scoped context which is cancelled
+	// after the handler returns; the watcher must outlive the request.
+	watchCtx, cancel := context.WithCancel(context.WithoutCancel(ctx)) //nolint:gosec // cancel is stored in s.watchCancel and called on next restart or shutdown
 	s.watchCancel = cancel
 	go func() {
 		if err := s.watchTaskfiles(watchCtx); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1481,3 +1481,94 @@ func TestWatchTaskfiles_NewSubdirectory(t *testing.T) {
 		}
 	}
 }
+
+func TestToolListChangedNotification_OnFileChange(t *testing.T) {
+	dir := t.TempDir()
+	initial := []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n")
+	if err := os.WriteFile(filepath.Join(dir, "Taskfile.yml"), initial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := NewTaskfileServer()
+	ctx := t.Context()
+
+	rootURI := dirToURI(dir)
+
+	// Track notifications received by the client.
+	notified := make(chan struct{}, 10)
+
+	client := mcp.NewClient(
+		&mcp.Implementation{Name: "test-client", Version: "0.0.0"},
+		&mcp.ClientOptions{
+			ToolListChangedHandler: func(_ context.Context, _ *mcp.ToolListChangedRequest) {
+				notified <- struct{}{}
+			},
+		},
+	)
+	client.AddRoots(&mcp.Root{URI: rootURI, Name: "test"})
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, &mcp.ServerOptions{
+		InitializedHandler:      ts.handleInitialized,
+		RootsListChangedHandler: ts.handleRootsChanged,
+	})
+	ts.mcpServer = server
+	ts.registeredTools = make(map[string]mcp.Tool)
+
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	// Wait for initial tools to be registered.
+	waitForTools(t, ts, 1)
+
+	// Drain any notifications from the initial tool registration.
+	drainDone := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case <-notified:
+		case <-drainDone:
+			break drain
+		}
+	}
+
+	// Write an updated Taskfile with a new task.
+	updated := []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n  goodbye:\n    desc: Say goodbye\n    cmds:\n      - echo goodbye\n")
+	if err := os.WriteFile(filepath.Join(dir, "Taskfile.yml"), updated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the server to reload and register the new tool.
+	waitForTools(t, ts, 2)
+
+	// The client should receive a tools/list_changed notification.
+	select {
+	case <-notified:
+		// success — notification was delivered
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for tools/list_changed notification from file change")
+	}
+
+	// Verify the client can see the new tool via ListTools.
+	toolsRes, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	toolNames := make(map[string]bool)
+	for _, tool := range toolsRes.Tools {
+		toolNames[tool.Name] = true
+	}
+	if !toolNames["goodbye"] {
+		t.Errorf("expected tool %q in ListTools response, got: %v", "goodbye", toolNames)
+	}
+}


### PR DESCRIPTION
The `restartWatchers` method was deriving its watcher context from the request-scoped context passed to `InitializedHandler` and `RootsListChangedHandler`. The go-sdk cancels this context immediately after the handler returns, causing the file watcher goroutines to exit before processing any events. This meant `tools/list_changed` notifications were never sent to connected clients when Taskfiles changed on disk.

This was a regression introduced by the multi-root refactor (#27/#28), which moved watcher startup from `run()` (using a long-lived `context.Background()`) into the lifecycle handlers (using short-lived request contexts).

- Use `context.WithoutCancel(ctx)` in `restartWatchers` to detach from the request-scoped cancellation while preserving the context chain
- Watcher lifecycle continues to be managed explicitly via the stored cancel function (`s.watchCancel`)
- Add an end-to-end test that verifies a connected client receives the `tools/list_changed` notification when a Taskfile is modified on disk