### PR TITLE
fix: resolve watcher lifecycle races and enable race detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
   test:
     desc: Run tests
     cmds:
-      - go test ./...
+      - go test -race ./...
 
   build:
     desc: Build the server binary

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ type TaskfileServer struct {
 	registeredTools map[string]mcp.Tool
 	mu              sync.Mutex
 	watchCancel     context.CancelFunc
+	watchDone       chan struct{}
 }
 
 // dirToURI converts an absolute directory path to a file:// URI.
@@ -506,12 +507,17 @@ func (s *TaskfileServer) watchRootTaskfiles(ctx context.Context, uri string, roo
 	defer func() {
 		_ = watcher.Close()
 		s.mu.Lock()
-		root.watcher = nil
+		if root.watcher == watcher {
+			root.watcher = nil
+		}
 		s.mu.Unlock()
 	}()
 
 	// Recursively add all directories under the root's workdir.
 	err = filepath.WalkDir(root.workdir, func(path string, d fs.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err != nil {
 			return err
 		}
@@ -521,19 +527,31 @@ func (s *TaskfileServer) watchRootTaskfiles(ctx context.Context, uri string, roo
 		return nil
 	})
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
 		return fmt.Errorf("failed to walk working directory: %w", err)
 	}
 
 	const debounce = 200 * time.Millisecond
-	var timer *time.Timer
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	timerPending := false
 
 	for {
 		select {
 		case <-ctx.Done():
-			if timer != nil {
-				timer.Stop()
+			if !timer.Stop() && timerPending {
+				<-timer.C
 			}
 			return nil
+		case <-timer.C:
+			timerPending = false
+			if err := s.reloadRoot(uri); err != nil {
+				log.Printf("failed to reload tools for root %s: %v", uri, err)
+			}
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return nil
@@ -551,14 +569,11 @@ func (s *TaskfileServer) watchRootTaskfiles(ctx context.Context, uri string, roo
 			}
 
 			// Debounce rapid events.
-			if timer != nil {
-				timer.Stop()
+			if !timer.Stop() && timerPending {
+				<-timer.C
 			}
-			timer = time.AfterFunc(debounce, func() {
-				if err := s.reloadRoot(uri); err != nil {
-					log.Printf("failed to reload tools for root %s: %v", uri, err)
-				}
-			})
+			timer.Reset(debounce)
+			timerPending = true
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return nil
@@ -568,16 +583,23 @@ func (s *TaskfileServer) watchRootTaskfiles(ctx context.Context, uri string, roo
 	}
 }
 
-// watchTaskfiles starts file watchers for all roots and blocks until the
-// context is cancelled.
-func (s *TaskfileServer) watchTaskfiles(ctx context.Context) error {
+// rootSnapshot is a URI→rootState pair captured under lock for use by
+// watchTaskfiles without holding the mutex.
+type rootSnapshot struct {
+	uri  string
+	root *rootState
+}
+
+// watchTaskfiles starts file watchers for the given roots and blocks until the
+// context is cancelled. The caller must provide a snapshot captured under lock.
+func (s *TaskfileServer) watchTaskfiles(ctx context.Context, roots []rootSnapshot) error {
 	var wg sync.WaitGroup
 	var firstErr error
 	var errOnce sync.Once
 
-	for uri, root := range s.roots {
+	for _, rs := range roots {
 		wg.Go(func() {
-			if err := s.watchRootTaskfiles(ctx, uri, root); err != nil {
+			if err := s.watchRootTaskfiles(ctx, rs.uri, rs.root); err != nil {
 				errOnce.Do(func() { firstErr = err })
 			}
 		})
@@ -594,20 +616,46 @@ func isMethodNotFound(err error) bool {
 	return errors.As(err, &wireErr) && wireErr.Code == jsonrpc.CodeMethodNotFound
 }
 
-// restartWatchers cancels any running file watchers and starts new ones
-// for all current roots. The provided ctx is intentionally detached via
-// context.WithoutCancel because callers pass request-scoped contexts
-// that are cancelled after the handler returns.
+// restartWatchers cancels any running file watchers, waits for them to
+// exit, then starts new ones for all current roots. The caller must hold
+// s.mu; it is temporarily released while waiting for old watchers so
+// that watcher goroutines calling reloadRoot can acquire the lock. The
+// provided ctx is intentionally detached via context.WithoutCancel
+// because callers pass request-scoped contexts that are cancelled after
+// the handler returns.
 func (s *TaskfileServer) restartWatchers(ctx context.Context) {
-	if s.watchCancel != nil {
-		s.watchCancel()
+	// Capture previous watcher generation's cancel and done channel.
+	prevCancel := s.watchCancel
+	prevDone := s.watchDone
+
+	// Snapshot roots while we hold the lock.
+	snap := make([]rootSnapshot, 0, len(s.roots))
+	for uri, root := range s.roots {
+		snap = append(snap, rootSnapshot{uri: uri, root: root})
 	}
+
+	// Prepare the new watcher generation before releasing the lock.
 	// Detach from the caller's request-scoped context which is cancelled
 	// after the handler returns; the watcher must outlive the request.
 	watchCtx, cancel := context.WithCancel(context.WithoutCancel(ctx)) //nolint:gosec // cancel is stored in s.watchCancel and called on next restart or shutdown
+	done := make(chan struct{})
 	s.watchCancel = cancel
+	s.watchDone = done
+
+	// Release lock while waiting for old watchers so they can acquire
+	// it during teardown (e.g. clearing root.watcher).
+	s.mu.Unlock()
+	if prevCancel != nil {
+		prevCancel()
+	}
+	if prevDone != nil {
+		<-prevDone
+	}
+	s.mu.Lock()
+
 	go func() {
-		if err := s.watchTaskfiles(watchCtx); err != nil {
+		defer close(done)
+		if err := s.watchTaskfiles(watchCtx, snap); err != nil {
 			log.Printf("file watcher failed: %v", err)
 		}
 	}()

--- a/main_test.go
+++ b/main_test.go
@@ -631,7 +631,7 @@ func TestWatchTaskfiles_ReloadsOnChange(t *testing.T) {
 	ctx := t.Context()
 
 	go func() {
-		_ = s.watchTaskfiles(ctx)
+		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
 	}()
 
 	// Give the watcher time to start.
@@ -653,7 +653,10 @@ func TestWatchTaskfiles_ReloadsOnChange(t *testing.T) {
 		case <-deadline:
 			t.Fatal("timed out waiting for tool reload")
 		case <-ticker.C:
-			if _, ok := s.registeredTools["goodbye"]; ok {
+			s.mu.Lock()
+			_, ok := s.registeredTools["goodbye"]
+			s.mu.Unlock()
+			if ok {
 				return // success
 			}
 		}
@@ -672,7 +675,7 @@ func TestWatchTaskfiles_IgnoresNonTaskfile(t *testing.T) {
 	ctx := t.Context()
 
 	go func() {
-		_ = s.watchTaskfiles(ctx)
+		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
 	}()
 
 	time.Sleep(100 * time.Millisecond)
@@ -686,8 +689,11 @@ func TestWatchTaskfiles_IgnoresNonTaskfile(t *testing.T) {
 	time.Sleep(400 * time.Millisecond)
 
 	// Tools should remain unchanged.
-	if len(s.registeredTools) != 1 {
-		t.Errorf("expected 1 tool, got %d", len(s.registeredTools))
+	s.mu.Lock()
+	n := len(s.registeredTools)
+	s.mu.Unlock()
+	if n != 1 {
+		t.Errorf("expected 1 tool, got %d", n)
 	}
 }
 
@@ -703,7 +709,7 @@ func TestWatchTaskfiles_CancelStops(t *testing.T) {
 	done := make(chan error, 1)
 
 	go func() {
-		done <- s.watchTaskfiles(ctx)
+		done <- s.watchTaskfiles(ctx, snapshotRoots(s))
 	}()
 
 	time.Sleep(50 * time.Millisecond)
@@ -717,6 +723,15 @@ func TestWatchTaskfiles_CancelStops(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("watchTaskfiles did not stop after context cancellation")
 	}
+}
+
+// snapshotRoots returns a rootSnapshot slice for use with watchTaskfiles.
+func snapshotRoots(s *TaskfileServer) []rootSnapshot {
+	snap := make([]rootSnapshot, 0, len(s.roots))
+	for uri, root := range s.roots {
+		snap = append(snap, rootSnapshot{uri: uri, root: root})
+	}
+	return snap
 }
 
 // newTempServer creates a TaskfileServer backed by a temp directory containing
@@ -851,7 +866,7 @@ func TestWatchTaskfiles_DebounceCoalesces(t *testing.T) {
 	ctx := t.Context()
 
 	go func() {
-		_ = s.watchTaskfiles(ctx)
+		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
 	}()
 
 	time.Sleep(100 * time.Millisecond)
@@ -875,7 +890,9 @@ func TestWatchTaskfiles_DebounceCoalesces(t *testing.T) {
 		case <-deadline:
 			t.Fatal("timed out waiting for debounced reload")
 		case <-ticker.C:
+			s.mu.Lock()
 			tool, ok := s.registeredTools["hello"]
+			s.mu.Unlock()
 			if ok && tool.Description == "Attempt 4" {
 				return // success — final write was applied
 			}
@@ -1437,7 +1454,7 @@ func TestWatchTaskfiles_NewSubdirectory(t *testing.T) {
 	ctx := t.Context()
 
 	go func() {
-		_ = s.watchTaskfiles(ctx)
+		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
 	}()
 
 	time.Sleep(100 * time.Millisecond)
@@ -1473,9 +1490,15 @@ func TestWatchTaskfiles_NewSubdirectory(t *testing.T) {
 	for {
 		select {
 		case <-deadline:
-			t.Fatalf("timed out waiting for sub-task; registered tools: %v", toolNames(s.registeredTools))
+			s.mu.Lock()
+			names := toolNames(s.registeredTools)
+			s.mu.Unlock()
+			t.Fatalf("timed out waiting for sub-task; registered tools: %v", names)
 		case <-ticker.C:
-			if _, ok := s.registeredTools["sub_sub-task"]; ok {
+			s.mu.Lock()
+			_, ok := s.registeredTools["sub_sub-task"]
+			s.mu.Unlock()
+			if ok {
 				return // success
 			}
 		}


### PR DESCRIPTION
Fix multiple data races and lifecycle bugs in the file watcher subsystem introduced during the multi-root refactor. Enable `-race` in the test task to catch these issues going forward.

- Fix data race on `s.roots` by introducing `rootSnapshot` and passing a snapshot to `watchTaskfiles` instead of reading the shared map without the mutex
- Prevent old watcher defer from clobbering a new `root.watcher` by comparing before clearing
- Ensure `restartWatchers` waits for the previous watcher generation to exit before starting new ones via a `watchDone` channel, with careful lock release to avoid deadlock
- Replace `time.AfterFunc` debounce with an in-goroutine `time.Timer` reset pattern to prevent stale callbacks firing after cancellation
- Make `WalkDir` cancellation-aware so old watchers abort promptly on restart
- Guard test poll loops with `s.mu` to fix races on `s.registeredTools`
- Enable `-race` flag in the Taskfile test command