### PR TITLE
fix(watcher): withdraw stale tools on reload failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The server resolves each root's Taskfile graph using `go-task`, then watches the
 4. Notifies connected clients of the change (`notifications/tools/list_changed`)
 
 After each reload, the server recomputes the graph-derived watch set so newly included local Taskfiles start being watched and removed ones stop being watched. File system events are debounced (~200 ms) to avoid redundant reloads during rapid edits. The watcher runs for the lifetime of the server and is cleaned up on shutdown.
+If a root Taskfile becomes invalid or is deleted, the server withdraws that root's tools until a valid Taskfile is restored.
 
 ## Error Handling
 

--- a/main.go
+++ b/main.go
@@ -466,7 +466,7 @@ func (s *TaskfileServer) buildToolSet() (map[string]mcp.Tool, map[string]mcp.Too
 	}
 
 	for _, root := range s.roots {
-		if root.taskfile.Tasks == nil {
+		if root.taskfile == nil || root.taskfile.Tasks == nil {
 			continue
 		}
 
@@ -541,6 +541,15 @@ func (s *TaskfileServer) syncTools() error {
 	return nil
 }
 
+// disableRootTools clears the loaded Taskfile state for a root and syncs the
+// server so any previously registered tools are withdrawn. The existing watch
+// set is preserved so restoring the Taskfile can be detected and reloaded.
+func (s *TaskfileServer) disableRootTools(root *rootState) error {
+	root.executor = nil
+	root.taskfile = nil
+	return s.syncTools()
+}
+
 // isTaskfile reports whether the given path's basename matches one of the
 // supported Taskfile filenames from taskfile.DefaultTaskfiles.
 func isTaskfile(path string) bool {
@@ -560,7 +569,10 @@ func (s *TaskfileServer) reloadRoot(ctx context.Context, uri string) error {
 
 	watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, root.workdir)
 	if err != nil {
-		return err
+		if syncErr := s.disableRootTools(root); syncErr != nil {
+			return fmt.Errorf("failed to reload root %s: %w", uri, errors.Join(err, fmt.Errorf("failed to clear stale tools: %w", syncErr)))
+		}
+		return fmt.Errorf("failed to reload root %s: %w", uri, err)
 	}
 
 	executor := task.NewExecutor(
@@ -568,6 +580,9 @@ func (s *TaskfileServer) reloadRoot(ctx context.Context, uri string) error {
 		task.WithSilent(true),
 	)
 	if err := executor.Setup(); err != nil {
+		if syncErr := s.disableRootTools(root); syncErr != nil {
+			return fmt.Errorf("failed to setup task executor for %s: %w", root.workdir, errors.Join(err, fmt.Errorf("failed to clear stale tools: %w", syncErr)))
+		}
 		return fmt.Errorf("failed to setup task executor for %s: %w", root.workdir, err)
 	}
 	root.executor = executor

--- a/main_test.go
+++ b/main_test.go
@@ -1113,6 +1113,100 @@ func TestWatchTaskfiles_DebounceCoalesces(t *testing.T) {
 	}
 }
 
+func TestWatchTaskfiles_InvalidRootTaskfileRemovesToolsUntilRestored(t *testing.T) {
+	initial := []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n")
+	s := newTempServer(t, initial)
+	root := onlyRoot(t, s)
+
+	ctx := t.Context()
+
+	go func() {
+		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	invalid := []byte("version: '3'\ntasks:\n  hello:\n    desc: Broken hello\n    cmds:\n      - echo hello\n    vars: [\n")
+	if err := os.WriteFile(filepath.Join(root.workdir, "Taskfile.yml"), invalid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForToolCount(t, s, 0)
+
+	restored := []byte("version: '3'\ntasks:\n  hello:\n    desc: Restored hello\n    cmds:\n      - echo hello again\n")
+	if err := os.WriteFile(filepath.Join(root.workdir, "Taskfile.yml"), restored, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			s.mu.Lock()
+			tool := s.registeredTools["hello"]
+			s.mu.Unlock()
+			t.Fatalf("timed out waiting for restored Taskfile reload; last tool state: %+v", tool)
+		case <-ticker.C:
+			s.mu.Lock()
+			tool, ok := s.registeredTools["hello"]
+			s.mu.Unlock()
+			if ok && tool.Description == "Restored hello" {
+				return
+			}
+		}
+	}
+}
+
+func TestWatchTaskfiles_DeletedRootTaskfileRemovesToolsUntilRestored(t *testing.T) {
+	initial := []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n")
+	s := newTempServer(t, initial)
+	root := onlyRoot(t, s)
+
+	ctx := t.Context()
+
+	go func() {
+		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	taskfilePath := filepath.Join(root.workdir, "Taskfile.yml")
+	if err := os.Remove(taskfilePath); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForToolCount(t, s, 0)
+
+	restored := []byte("version: '3'\ntasks:\n  hello:\n    desc: Recreated hello\n    cmds:\n      - echo hello again\n")
+	if err := os.WriteFile(taskfilePath, restored, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			s.mu.Lock()
+			tool := s.registeredTools["hello"]
+			s.mu.Unlock()
+			t.Fatalf("timed out waiting for recreated Taskfile reload; last tool state: %+v", tool)
+		case <-ticker.C:
+			s.mu.Lock()
+			tool, ok := s.registeredTools["hello"]
+			s.mu.Unlock()
+			if ok && tool.Description == "Recreated hello" {
+				return
+			}
+		}
+	}
+}
+
 func TestHandleInitialized_WithRoots(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "Taskfile.yml"), []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n"), 0o600); err != nil {


### PR DESCRIPTION
This PR fixes stale MCP tools after a watched root Taskfile becomes invalid or is deleted. Instead of leaving the previous executor state in place when reloads fail, the server now withdraws that root's tools until a valid Taskfile is restored, which keeps the exposed tool surface aligned with the actual workspace state.

- clear a root's loaded Taskfile state and resync tools when graph parsing or executor setup fails during reload
- preserve the existing watch subscriptions so restore events still trigger recovery and tool re-registration
- add watcher regression tests for invalid and deleted root Taskfiles, including restoration, and document the behavior

Closes #34
