### PR TITLE
fix: parse local file root URIs correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -90,19 +91,51 @@ func dirToURI(dir string) string {
 	if err != nil {
 		abs = dir
 	}
-	return "file://" + filepath.ToSlash(abs)
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}).String()
 }
 
 // uriToDir converts a file:// URI back to a local directory path.
 func uriToDir(uri string) (string, error) {
-	u, err := url.Parse(uri)
+	return fileURIToPath(uri)
+}
+
+// fileURIToPath parses a local file:// URI into a filesystem path.
+func fileURIToPath(raw string) (string, error) {
+	u, err := url.Parse(raw)
 	if err != nil {
-		return "", fmt.Errorf("invalid URI %q: %w", uri, err)
+		return "", fmt.Errorf("invalid URI %q: %w", raw, err)
 	}
 	if u.Scheme != "file" {
 		return "", fmt.Errorf("unsupported URI scheme %q (only file:// is supported)", u.Scheme)
 	}
-	return filepath.FromSlash(u.Path), nil
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("file URI %q must not include query or fragment", raw)
+	}
+	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
+		return "", fmt.Errorf("UNC file URI %q is not supported", raw)
+	}
+
+	path := u.Path
+	if path == "" {
+		return "", fmt.Errorf("file URI %q is missing a path", raw)
+	}
+	if isWindowsDriveURIPath(path) {
+		if runtime.GOOS != "windows" {
+			return "", fmt.Errorf("windows file URI %q is not supported on %s", raw, runtime.GOOS)
+		}
+		path = strings.TrimPrefix(path, "/")
+	}
+
+	return filepath.Clean(filepath.FromSlash(path)), nil
+}
+
+func isWindowsDriveURIPath(path string) bool {
+	if len(path) < 3 || path[0] != '/' || path[2] != ':' {
+		return false
+	}
+
+	drive := path[1]
+	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
 }
 
 // validRootPrefixChars matches characters NOT allowed in a root prefix.
@@ -206,7 +239,12 @@ func taskfileLocationToPath(location string) (string, bool, error) {
 		return "", false, nil
 	}
 
-	return filepath.Clean(filepath.FromSlash(u.Path)), true, nil
+	path, err := fileURIToPath(location)
+	if err != nil {
+		return "", false, err
+	}
+
+	return path, true, nil
 }
 
 // sortedKeys returns the sorted keys of a string set.

--- a/main_test.go
+++ b/main_test.go
@@ -502,24 +502,110 @@ func TestIsTaskfile(t *testing.T) {
 }
 
 func TestDirToURI(t *testing.T) {
-	uri := dirToURI("/some/path")
-	if uri != "file:///some/path" {
-		t.Errorf("dirToURI(%q) = %q, want %q", "/some/path", uri, "file:///some/path")
+	dir := filepath.Join(t.TempDir(), "path with #hash and ?query")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	uri := dirToURI(dir)
+	if strings.Contains(uri, "#") || strings.Contains(uri, "?") {
+		t.Fatalf("dirToURI(%q) returned unescaped URI %q", dir, uri)
+	}
+
+	roundTrip, err := uriToDir(uri)
+	if err != nil {
+		t.Fatalf("uriToDir(%q) failed: %v", uri, err)
+	}
+	if roundTrip != filepath.Clean(dir) {
+		t.Errorf("uri round-trip = %q, want %q", roundTrip, filepath.Clean(dir))
 	}
 }
 
 func TestURIToDir(t *testing.T) {
-	dir, err := uriToDir("file:///some/path")
-	if err != nil {
-		t.Fatalf("uriToDir failed: %v", err)
+	dir := filepath.Join(t.TempDir(), "path with #hash and ?query")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
 	}
-	if dir != "/some/path" {
-		t.Errorf("uriToDir = %q, want %q", dir, "/some/path")
+	want := filepath.Clean(dir)
+	uri := dirToURI(dir)
+	localhostURI := strings.Replace(uri, "file://", "file://localhost", 1)
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr string
+	}{
+		{name: "local file URI", uri: uri, want: want},
+		{name: "localhost file URI", uri: localhostURI, want: want},
+		{name: "non-file URI", uri: "https://example.com", wantErr: `unsupported URI scheme "https"`},
+		{name: "fragment", uri: "file:///tmp/a#b", wantErr: "must not include query or fragment"},
+		{name: "query", uri: "file:///tmp/a?b", wantErr: "must not include query or fragment"},
+		{name: "unc", uri: "file://server/share", wantErr: "UNC file URI"},
+	}
+	if runtime.GOOS == "windows" {
+		tests = append(tests, struct {
+			name    string
+			uri     string
+			want    string
+			wantErr string
+		}{name: "windows drive URI", uri: "file:///C:/repo", want: filepath.Clean(`C:\repo`)})
+	} else {
+		tests = append(tests, struct {
+			name    string
+			uri     string
+			want    string
+			wantErr string
+		}{name: "windows drive URI", uri: "file:///C:/repo", wantErr: "windows file URI"})
 	}
 
-	_, err = uriToDir("https://example.com")
-	if err == nil {
-		t.Error("expected error for non-file URI")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := uriToDir(tt.uri)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("uriToDir(%q) = %q, want error containing %q", tt.uri, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("uriToDir(%q) error = %q, want substring %q", tt.uri, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("uriToDir(%q) failed: %v", tt.uri, err)
+			}
+			if got != tt.want {
+				t.Fatalf("uriToDir(%q) = %q, want %q", tt.uri, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskfileLocationToPath_FileURI(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "taskfile with #hash")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := taskfileLocationToPath(dirToURI(dir))
+	if err != nil {
+		t.Fatalf("taskfileLocationToPath failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected file URI to be treated as local")
+	}
+	if got != filepath.Clean(dir) {
+		t.Fatalf("taskfileLocationToPath = %q, want %q", got, filepath.Clean(dir))
+	}
+}
+
+func TestTaskfileLocationToPath_IgnoresNonLocalURI(t *testing.T) {
+	got, ok, err := taskfileLocationToPath("https://example.com/Taskfile.yml")
+	if err != nil {
+		t.Fatalf("taskfileLocationToPath returned error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected non-file URI to be ignored, got %q", got)
 	}
 }
 


### PR DESCRIPTION
This PR fixes issue 37 by making root `file://` URI handling correct for local-disk paths and by failing clearly for unsupported non-local forms. It replaces the previous string-concatenation and path-only parsing with a shared helper so root loading and graph-derived Taskfile path normalization interpret local file URIs consistently.

- build `file://` URIs with proper escaping so local paths containing URI-significant characters round-trip correctly
- parse local file URIs through a shared helper used by both root loading and Taskfile graph location normalization
- reject unsupported UNC authorities instead of silently dropping the host and resolving the wrong directory
- add regression coverage for escaped local paths, `file://localhost/...`, Windows drive URIs, and unsupported non-local file URIs

Closes #37