### PR TITLE
fix(taskfileserver): require taskfiles in the provided root

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ mcp-taskfile-server
 
 After the client handshake completes, the server calls `roots/list` to discover which directories to load Taskfiles from. Clients that support the MCP [Roots](https://modelcontextprotocol.io/specification/2025-11-25/client/roots) capability can provide one or more `file://` root URIs. If the client does not support roots (returns JSON-RPC `-32601`), the server falls back to the current working directory.
 
+Each root is expected to be the directory that directly contains the top-level Taskfile for that workspace. The server checks only that exact root directory for supported Taskfile filenames and does not walk parent directories.
+
 Equivalent local file URI aliases are canonicalized before they enter server state, so values such as `file:///repo` and `file://localhost/repo` share a single internal root identity.
 
 When roots change at runtime (`notifications/roots/list_changed`), the server automatically diffs the root set, tears down removed roots (stopping their file watchers and unregistering their tools), and loads any newly added roots.

--- a/internal/taskfileserver/roots.go
+++ b/internal/taskfileserver/roots.go
@@ -90,13 +90,14 @@ func loadRoot(ctx context.Context, dir string) (*Root, error) {
 		return nil, fmt.Errorf("failed to resolve path: %w", err)
 	}
 
-	watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, abs)
+	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, abs)
 	if err != nil {
 		return nil, err
 	}
 
 	executor := task.NewExecutor(
 		task.WithDir(abs),
+		task.WithEntrypoint(entrypoint),
 		task.WithSilent(true),
 	)
 
@@ -137,7 +138,7 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 	workdir := root.workdir
 	s.mu.Unlock()
 
-	watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, workdir)
+	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, workdir)
 	if err != nil {
 		s.mu.Lock()
 		s.disableRootToolsLocked(root)
@@ -151,6 +152,7 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 
 	executor := task.NewExecutor(
 		task.WithDir(workdir),
+		task.WithEntrypoint(entrypoint),
 		task.WithSilent(true),
 	)
 	if err := executor.Setup(); err != nil {

--- a/internal/taskfileserver/roots_test.go
+++ b/internal/taskfileserver/roots_test.go
@@ -149,6 +149,22 @@ func TestCanonicalRootURI(t *testing.T) {
 	}
 }
 
+func TestLoadRoot_DoesNotWalkParentDirectories(t *testing.T) {
+	parent := t.TempDir()
+	if err := os.WriteFile(filepath.Join(parent, "Taskfile.yml"), []byte("version: '3'\ntasks:\n  parent:\n    cmds:\n      - echo parent\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(parent, "child")
+	if err := os.Mkdir(child, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadRoot(t.Context(), child); err == nil {
+		t.Fatal("expected loadRoot to fail when the root has no direct Taskfile")
+	}
+}
+
 func TestTaskfileLocationToPath_FileURI(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "taskfile with #hash")
 	if err := os.MkdirAll(dir, 0o750); err != nil {

--- a/internal/taskfileserver/taskgraph.go
+++ b/internal/taskfileserver/taskgraph.go
@@ -2,8 +2,10 @@ package taskfileserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"slices"
 
@@ -12,20 +14,25 @@ import (
 
 // loadTaskfileWatchSet reads the resolved Taskfile graph for a root and returns
 // the local Taskfile files and parent directories that should be watched.
-func loadTaskfileWatchSet(ctx context.Context, dir string) (map[string]struct{}, []string, error) {
-	rootNode, err := taskfile.NewRootNode("", dir, false, 0)
+func loadTaskfileWatchSet(ctx context.Context, dir string) (string, map[string]struct{}, []string, error) {
+	entrypoint, err := resolveRootTaskfile(dir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to resolve root Taskfile for %s: %w", dir, err)
+		return "", nil, nil, fmt.Errorf("failed to resolve root Taskfile for %s: %w", dir, err)
+	}
+
+	rootNode, err := taskfile.NewRootNode(entrypoint, dir, false, 0)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to resolve root Taskfile for %s: %w", dir, err)
 	}
 
 	graph, err := taskfile.NewReader().Read(ctx, rootNode)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read Taskfile graph for %s: %w", dir, err)
+		return "", nil, nil, fmt.Errorf("failed to read Taskfile graph for %s: %w", dir, err)
 	}
 
 	adjacencyMap, err := graph.AdjacencyMap()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to inspect Taskfile graph for %s: %w", dir, err)
+		return "", nil, nil, fmt.Errorf("failed to inspect Taskfile graph for %s: %w", dir, err)
 	}
 
 	watchTaskfiles := make(map[string]struct{}, len(adjacencyMap))
@@ -33,7 +40,7 @@ func loadTaskfileWatchSet(ctx context.Context, dir string) (map[string]struct{},
 	for location := range adjacencyMap {
 		path, ok, err := taskfileLocationToPath(location)
 		if err != nil {
-			return nil, nil, err
+			return "", nil, nil, err
 		}
 		if !ok {
 			continue
@@ -42,7 +49,26 @@ func loadTaskfileWatchSet(ctx context.Context, dir string) (map[string]struct{},
 		watchDirs[filepath.Dir(path)] = struct{}{}
 	}
 
-	return watchTaskfiles, sortedKeys(watchDirs), nil
+	return entrypoint, watchTaskfiles, sortedKeys(watchDirs), nil
+}
+
+func resolveRootTaskfile(dir string) (string, error) {
+	for _, filename := range taskfile.DefaultTaskfiles {
+		path := filepath.Join(dir, filename)
+		info, err := os.Stat(path)
+		if err == nil {
+			if info.IsDir() {
+				continue
+			}
+			return filepath.Clean(path), nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return "", fmt.Errorf("failed to stat %s: %w", path, err)
+	}
+
+	return "", fmt.Errorf("no Taskfile found directly in root %s", dir)
 }
 
 // taskfileLocationToPath normalizes a Taskfile graph vertex location into a


### PR DESCRIPTION
This changes root Taskfile resolution so each client-provided workspace root must directly contain the top-level Taskfile for that workspace. It prevents go-task from walking up into parent directories and accidentally exposing tasks from ancestor folders when the root itself has no local Taskfile.

- resolve the root Taskfile only from the exact workspace root directory and pass that explicit entrypoint into go-task for both initial load and reload
- add a regression test covering a child directory without a local Taskfile so parent Taskfiles are no longer inherited
- document in the README that MCP roots are expected to point at the directory containing the top-level Taskfile
