### PR TITLE
fix: watch root Taskfiles created after startup

### DIFF
--- a/internal/taskfileserver/roots.go
+++ b/internal/taskfileserver/roots.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/go-task/task/v3"
+	"github.com/go-task/task/v3/taskfile"
 )
 
 // dirToURI converts an absolute directory path to a file:// URI.
@@ -109,6 +111,35 @@ func loadRoot(ctx context.Context, dir string) (*Root, error) {
 		taskfile:       executor.Taskfile,
 		workdir:        abs,
 		watchDirs:      watchDirs,
+		watchTaskfiles: watchTaskfiles,
+	}, nil
+}
+
+// newUnloadedRoot creates a root placeholder for a workspace that does not yet
+// have a loadable root Taskfile. Watching the root directory lets us pick up a
+// Taskfile that is created or fixed after startup.
+func newUnloadedRoot(dir string) (*Root, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat root %s: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root %s is not a directory", abs)
+	}
+
+	watchTaskfiles := make(map[string]struct{}, len(taskfile.DefaultTaskfiles))
+	for _, filename := range taskfile.DefaultTaskfiles {
+		watchTaskfiles[filepath.Join(abs, filename)] = struct{}{}
+	}
+
+	return &Root{
+		workdir:        abs,
+		watchDirs:      []string{abs},
 		watchTaskfiles: watchTaskfiles,
 	}, nil
 }

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -66,7 +66,11 @@ func (s *Server) reconcileRoots(ctx context.Context, roots []*mcp.Root, opts roo
 		root, loadErr := loadRoot(ctx, dir)
 		if loadErr != nil {
 			log.Printf("failed to load root %q: %v", r.URI, loadErr)
-			continue
+			root, loadErr = newUnloadedRoot(dir)
+			if loadErr != nil {
+				log.Printf("failed to watch unloaded root %q: %v", r.URI, loadErr)
+				continue
+			}
 		}
 		loadedRoots[canonicalURI] = root
 	}

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -287,6 +287,22 @@ func waitForToolCount(t *testing.T, ts *Server, count int) {
 	}
 }
 
+func testRoots(uris ...string) []*mcp.Root {
+	roots := make([]*mcp.Root, 0, len(uris))
+	for _, uri := range uris {
+		roots = append(roots, &mcp.Root{URI: uri})
+	}
+	return roots
+}
+
+// noopRegistry satisfies toolRegistry for tests that only care about the
+// server's in-memory tool bookkeeping, not MCP transport side effects.
+type noopRegistry struct{}
+
+func (noopRegistry) AddTool(_ *mcp.Tool, _ mcp.ToolHandler) {}
+
+func (noopRegistry) RemoveTools(_ ...string) {}
+
 // trackingRegistry wraps a toolRegistry and tracks the net set of tools
 // currently registered, providing an observable view of MCP-side state.
 type trackingRegistry struct {

--- a/internal/taskfileserver/watch_test.go
+++ b/internal/taskfileserver/watch_test.go
@@ -576,6 +576,61 @@ func TestWatchTaskfiles_DeletedRootTaskfileRemovesToolsUntilRestored(t *testing.
 	}
 }
 
+func TestReconcileRoots_MissingInitialTaskfileLoadsWhenCreatedLater(t *testing.T) {
+	dir := t.TempDir()
+	uri := dirToURI(dir)
+	s := New()
+	s.toolRegistry = noopRegistry{}
+	defer s.Shutdown()
+
+	if err := s.reconcileRoots(t.Context(), testRoots(uri), rootReconcileOptions{requireNonEmpty: true}); err != nil {
+		t.Fatalf("reconcileRoots: %v", err)
+	}
+
+	root := onlyRoot(t, s)
+	if root.taskfile != nil {
+		t.Fatal("expected root to be tracked without a loaded Taskfile")
+	}
+	if !slices.Equal(root.watchDirs, []string{dir}) {
+		t.Fatalf("watchDirs = %v, want [%s]", root.watchDirs, dir)
+	}
+	for _, filename := range []string{"Taskfile.yml", "Taskfile.yaml", "Taskfile.dist.yml", "Taskfile.dist.yaml"} {
+		if _, ok := root.watchTaskfiles[filepath.Join(dir, filename)]; !ok {
+			t.Fatalf("expected %s to be watched", filename)
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	taskfilePath := filepath.Join(dir, "Taskfile.yml")
+	content := []byte("version: '3'\ntasks:\n  hello:\n    desc: Added after startup\n    cmds:\n      - echo hello\n")
+	if err := os.WriteFile(taskfilePath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			s.mu.Lock()
+			tool := s.registeredTools["hello"]
+			s.mu.Unlock()
+			t.Fatalf("timed out waiting for created root Taskfile reload; last tool state: %+v", tool)
+		case <-ticker.C:
+			s.mu.Lock()
+			tool, ok := s.registeredTools["hello"]
+			loadedRoot := s.roots[uri]
+			s.mu.Unlock()
+			if ok && tool.Description == "Added after startup" && loadedRoot != nil && loadedRoot.taskfile != nil {
+				return
+			}
+		}
+	}
+}
+
 func TestReloadRoot_UnknownURI(t *testing.T) {
 	s := newTestServer(t, "basic")
 


### PR DESCRIPTION
This PR keeps workspace roots under watch even when they do not have a loadable root Taskfile at initialization time, so creating a Taskfile later causes the server to reload and expose tools. It fixes the regression introduced by restricting discovery to only direct root Taskfiles, where empty roots could no longer become active without a roots change event.

- keep unloaded roots in watch state by creating a placeholder root that watches supported Taskfile names in the workspace directory
- add a regression test for creating a root Taskfile after startup and lightweight test helpers so the watcher test stays focused on server behavior