### PR TITLE
fix(taskfileserver): snapshot tool state by value to isolate planner

### DIFF
--- a/internal/taskfileserver/naming.go
+++ b/internal/taskfileserver/naming.go
@@ -76,14 +76,14 @@ func sanitizeRootPrefix(name string) string {
 	return s
 }
 
-// rootPrefix returns the tool name prefix for a root. When there is only one
-// root the prefix is empty; with multiple roots it is derived from the root
-// directory's basename.
-func rootPrefix(root *Root, totalRoots int) string {
+// rootPrefix returns the tool name prefix for a root identified by its
+// working directory. When there is only one root the prefix is empty;
+// with multiple roots it is derived from the root directory's basename.
+func rootPrefix(workdir string, totalRoots int) string {
 	if totalRoots <= 1 {
 		return ""
 	}
-	return sanitizeRootPrefix(filepath.Base(root.workdir))
+	return sanitizeRootPrefix(filepath.Base(workdir))
 }
 
 // prefixedToolName returns the tool name with an optional root prefix.

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -2,7 +2,6 @@ package taskfileserver
 
 import (
 	"context"
-	"maps"
 	"sync"
 
 	"github.com/go-task/task/v3/taskfile/ast"
@@ -36,11 +35,21 @@ type Server struct {
 	shuttingDown    bool
 }
 
+// toolRootSnapshot is an immutable per-root view captured under lock so
+// the planner can run without holding s.mu and without dereferencing a
+// live *Root that another goroutine may mutate. The taskfile pointer is
+// captured by value: even if reloadRoot later swaps root.taskfile, this
+// snapshot keeps observing the AST that was current at snapshot time.
+type toolRootSnapshot struct {
+	workdir  string
+	taskfile *ast.Taskfile
+}
+
 // toolStateSnapshot captures the inputs needed by buildToolPlan,
 // frozen at a specific generation.
 type toolStateSnapshot struct {
 	generation uint64
-	roots      map[string]*Root
+	roots      map[string]toolRootSnapshot
 }
 
 // snapshotToolStateLocked returns a snapshot of the current tool-relevant
@@ -48,9 +57,14 @@ type toolStateSnapshot struct {
 func (s *Server) snapshotToolStateLocked() toolStateSnapshot {
 	snap := toolStateSnapshot{
 		generation: s.generation,
-		roots:      make(map[string]*Root, len(s.roots)),
+		roots:      make(map[string]toolRootSnapshot, len(s.roots)),
 	}
-	maps.Copy(snap.roots, s.roots)
+	for uri, root := range s.roots {
+		snap.roots[uri] = toolRootSnapshot{
+			workdir:  root.workdir,
+			taskfile: root.taskfile,
+		}
+	}
 	return snap
 }
 

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -114,8 +114,16 @@ func toolNames(tools map[string]mcp.Tool) []string {
 // snapshotFromServer builds a toolStateSnapshot from the server's current
 // roots without holding the mutex. Intended for tests only.
 func snapshotFromServer(s *Server) toolStateSnapshot {
-	snap := toolStateSnapshot{roots: make(map[string]*Root, len(s.roots))}
-	maps.Copy(snap.roots, s.roots)
+	snap := toolStateSnapshot{
+		generation: s.generation,
+		roots:      make(map[string]toolRootSnapshot, len(s.roots)),
+	}
+	for uri, root := range s.roots {
+		snap.roots[uri] = toolRootSnapshot{
+			workdir:  root.workdir,
+			taskfile: root.taskfile,
+		}
+	}
 	return snap
 }
 

--- a/internal/taskfileserver/tools.go
+++ b/internal/taskfileserver/tools.go
@@ -16,8 +16,10 @@ import (
 // createToolForTask creates an MCP tool definition for a given task.
 // The tool name is sanitized for MCP compatibility; the description
 // references the original Taskfile task name for clarity. The prefix
-// parameter is used in multi-root mode to namespace tool names.
-func createToolForTask(root *Root, prefix, taskName string, taskDef *ast.Task) *mcp.Tool {
+// parameter is used in multi-root mode to namespace tool names. The
+// taskfile is taken by value rather than via *Root so the planner can
+// run on a snapshot without touching live, mutable server state.
+func createToolForTask(tf *ast.Taskfile, prefix, taskName string, taskDef *ast.Task) *mcp.Tool {
 	toolName := sanitizeToolName(prefixedToolName(prefix, taskName))
 
 	description := taskDef.Desc
@@ -32,8 +34,8 @@ func createToolForTask(root *Root, prefix, taskName string, taskDef *ast.Task) *
 	allVars := make(map[string]ast.Var)
 
 	// Add global variables first
-	if root.taskfile.Vars != nil && root.taskfile.Vars.Len() > 0 {
-		maps.Insert(allVars, root.taskfile.Vars.All())
+	if tf.Vars != nil && tf.Vars.Len() > 0 {
+		maps.Insert(allVars, tf.Vars.All())
 	}
 
 	// Add task-specific variables (these override global ones)
@@ -99,7 +101,7 @@ type toolPlan struct {
 // without accessing or mutating the server.
 func buildToolPlan(snap toolStateSnapshot) toolPlan {
 	type toolCandidate struct {
-		root     *Root
+		workdir  string
 		taskName string
 		tool     mcp.Tool
 		handler  mcp.ToolHandler
@@ -116,16 +118,16 @@ func buildToolPlan(snap toolStateSnapshot) toolPlan {
 			continue
 		}
 
-		prefix := rootPrefix(root, len(snap.roots))
+		prefix := rootPrefix(root.workdir, len(snap.roots))
 
 		for taskName, taskDef := range root.taskfile.Tasks.All(nil) {
 			if taskDef.Internal {
 				continue
 			}
 
-			tool := createToolForTask(root, prefix, taskName, taskDef)
+			tool := createToolForTask(root.taskfile, prefix, taskName, taskDef)
 			candidates[tool.Name] = append(candidates[tool.Name], toolCandidate{
-				root:     root,
+				workdir:  root.workdir,
 				taskName: taskName,
 				tool:     *tool,
 				handler:  createTaskHandlerForWorkdir(root.workdir, taskName),
@@ -144,7 +146,7 @@ func buildToolPlan(snap toolStateSnapshot) toolPlan {
 		if len(group) > 1 {
 			details := make([]string, 0, len(group))
 			for _, candidate := range group {
-				details = append(details, fmt.Sprintf("%s (%s)", candidate.taskName, candidate.root.workdir))
+				details = append(details, fmt.Sprintf("%s (%s)", candidate.taskName, candidate.workdir))
 			}
 			slices.Sort(details)
 			log.Printf("excluding colliding tool name %q from MCP exposure: %s", name, strings.Join(details, ", "))

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -921,3 +921,30 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 		t.Fatal("MCP server missing taskA")
 	}
 }
+
+// TestSnapshotToolState_IsolatedFromRootMutation verifies that a snapshot
+// captured by snapshotToolStateLocked observes the taskfile pointer that
+// was current at snapshot time, even if the underlying *Root is mutated
+// in-place afterwards (as reloadRoot and disableRootToolsLocked do).
+// Before snapshotting copied per-root fields by value, this test would
+// have observed a nil taskfile in the snapshot and panicked in the
+// planner.
+func TestSnapshotToolState_IsolatedFromRootMutation(t *testing.T) {
+	s := loadServerFromFixture(t, "basic")
+	root := onlyRoot(t, s)
+
+	s.mu.Lock()
+	snap := s.snapshotToolStateLocked()
+	// Simulate disableRootToolsLocked clearing the live root in place.
+	root.taskfile = nil
+	s.generation++
+	s.mu.Unlock()
+
+	// Planner must run safely against the snapshot, observing the
+	// taskfile that was current at snapshot time, not the now-nil
+	// field on the live root.
+	plan := buildToolPlan(snap)
+	if _, ok := plan.tools["greet"]; !ok {
+		t.Fatalf("expected snapshotted plan to retain greet, got %v", toolNames(plan.tools))
+	}
+}

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -18,7 +18,7 @@ func TestCreateToolForTask_Basic(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	taskDef := lookupTask(t, root.taskfile, "greet")
-	tool := createToolForTask(root, "", "greet", taskDef)
+	tool := createToolForTask(root.taskfile, "", "greet", taskDef)
 
 	if tool.Name != "greet" {
 		t.Errorf("Name = %q, want %q", tool.Name, "greet")
@@ -38,7 +38,7 @@ func TestCreateToolForTask_NoDescription(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	taskDef := lookupTask(t, root.taskfile, "build")
-	tool := createToolForTask(root, "", "build", taskDef)
+	tool := createToolForTask(root.taskfile, "", "build", taskDef)
 
 	want := "Execute task: build"
 	if tool.Description != want {
@@ -51,7 +51,7 @@ func TestCreateToolForTask_TaskVars(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	taskDef := lookupTask(t, root.taskfile, "deploy")
-	tool := createToolForTask(root, "", "deploy", taskDef)
+	tool := createToolForTask(root.taskfile, "", "deploy", taskDef)
 
 	props := schemaProperties(t, tool)
 	if len(props) != 2 {
@@ -76,7 +76,7 @@ func TestCreateToolForTask_GlobalVars(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	taskDef := lookupTask(t, root.taskfile, "info")
-	tool := createToolForTask(root, "", "info", taskDef)
+	tool := createToolForTask(root.taskfile, "", "info", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["APP_NAME"]
@@ -96,7 +96,7 @@ func TestCreateToolForTask_OverrideVars(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	taskDef := lookupTask(t, root.taskfile, "deploy")
-	tool := createToolForTask(root, "", "deploy", taskDef)
+	tool := createToolForTask(root.taskfile, "", "deploy", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["ENV"]
@@ -218,7 +218,7 @@ func TestCreateToolForTask_Namespaced(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.taskName, func(t *testing.T) {
 			taskDef := lookupTask(t, root.taskfile, tt.taskName)
-			tool := createToolForTask(root, "", tt.taskName, taskDef)
+			tool := createToolForTask(root.taskfile, "", tt.taskName, taskDef)
 
 			if tool.Name != tt.wantTool {
 				t.Errorf("Name = %q, want %q", tool.Name, tt.wantTool)
@@ -236,7 +236,7 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 
 	t.Run("single wildcard", func(t *testing.T) {
 		taskDef := lookupTask(t, root.taskfile, "start:*")
-		tool := createToolForTask(root, "", "start:*", taskDef)
+		tool := createToolForTask(root.taskfile, "", "start:*", taskDef)
 
 		if tool.Name != "start" {
 			t.Errorf("Name = %q, want %q", tool.Name, "start")
@@ -255,7 +255,7 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 
 	t.Run("double wildcard", func(t *testing.T) {
 		taskDef := lookupTask(t, root.taskfile, "deploy:*:*")
-		tool := createToolForTask(root, "", "deploy:*:*", taskDef)
+		tool := createToolForTask(root.taskfile, "", "deploy:*:*", taskDef)
 
 		if tool.Name != "deploy" {
 			t.Errorf("Name = %q, want %q", tool.Name, "deploy")
@@ -280,7 +280,7 @@ func TestCreateToolForTask_LeadingDot(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	taskDef := lookupTask(t, root.taskfile, "uv:.venv")
-	tool := createToolForTask(root, "", "uv:.venv", taskDef)
+	tool := createToolForTask(root.taskfile, "", "uv:.venv", taskDef)
 
 	if tool.Name != "uv_.venv" {
 		t.Errorf("Name = %q, want %q", tool.Name, "uv_.venv")
@@ -652,7 +652,7 @@ func TestCreateToolForTask_WithPrefix(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	taskDef := lookupTask(t, root.taskfile, "greet")
-	tool := createToolForTask(root, "myproject", "greet", taskDef)
+	tool := createToolForTask(root.taskfile, "myproject", "greet", taskDef)
 
 	if tool.Name != "myproject_greet" {
 		t.Errorf("Name = %q, want %q", tool.Name, "myproject_greet")
@@ -668,7 +668,7 @@ func TestCreateToolForTask_WithPrefix_EnforcesMaxLength(t *testing.T) {
 	taskDef := lookupTask(t, root.taskfile, "greet")
 	prefix := strings.Repeat("project", 20)
 
-	tool := createToolForTask(root, prefix, "greet", taskDef)
+	tool := createToolForTask(root.taskfile, prefix, "greet", taskDef)
 
 	if len(tool.Name) != maxToolNameLength {
 		t.Fatalf("len(tool.Name) = %d, want %d", len(tool.Name), maxToolNameLength)
@@ -743,7 +743,9 @@ func TestBuildToolPlan_FromSnapshot(t *testing.T) {
 
 	snap := toolStateSnapshot{
 		generation: 42,
-		roots:      map[string]*Root{"file:///test": root},
+		roots: map[string]toolRootSnapshot{
+			"file:///test": {workdir: root.workdir, taskfile: root.taskfile},
+		},
 	}
 
 	plan := buildToolPlan(snap)


### PR DESCRIPTION
Hardens the snapshot/plan/apply tool synchronization so the planning phase no longer reaches into mutable, lock-protected `*Root` state. Previously `snapshotToolStateLocked` shallow-copied `s.roots`, leaving the planner to dereference `root.taskfile` without `s.mu` while `reloadRoot` and `disableRootToolsLocked` could swap that field in place — risking a torn read or nil-pointer panic when a root was reloaded or disabled mid-plan. The existing generation guard still discards stale plans, but the planner itself is now safe to run against an immutable view.

- Capture per-root fields the planner needs (`workdir` and the `*ast.Taskfile` pointer) into a new `toolRootSnapshot` value, and update `buildToolPlan`, `createToolForTask`, and `rootPrefix` to consume the snapshot rather than a live `*Root`.
- Add a regression test that snapshots state under lock, sets `root.taskfile` to nil in place, and verifies `buildToolPlan` still produces the expected tool from the snapshot.