### PR TITLE
refactor(taskfileserver): remove dead and duplicated state from Server

### DIFF
--- a/internal/taskfileserver/integration_test.go
+++ b/internal/taskfileserver/integration_test.go
@@ -30,7 +30,6 @@ func TestHandleInitialized_WithRoots(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -98,7 +97,6 @@ func TestHandleInitialized_CallToolExecutesSingleRootTool(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -153,7 +151,6 @@ func TestHandleInitialized_DeduplicatesEquivalentRootURIs(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -215,7 +212,6 @@ func TestHandleRootsChanged_AddAndRemove(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -282,7 +278,6 @@ func TestHandleRootsChanged_EquivalentURIAliasKeepsSingleRoot(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -369,7 +364,6 @@ func TestHandleInitialized_NoPublicTasks(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -424,7 +418,6 @@ func TestHandleRootsChanged_TransitionToUnprefixed(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -493,7 +486,6 @@ func TestHandleRootsChanged_TransitionToUnprefixedCallTool(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -554,7 +546,6 @@ func TestHandleRootsChanged_RemoveLastRootClearsTools(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 
@@ -617,7 +608,6 @@ func TestToolListChangedNotification_OnFileChange(t *testing.T) {
 		InitializedHandler:      ts.HandleInitialized,
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
-	ts.mcpServer = server
 	ts.toolRegistry = server
 	ts.registeredTools = make(map[string]mcp.Tool)
 

--- a/internal/taskfileserver/roots.go
+++ b/internal/taskfileserver/roots.go
@@ -23,17 +23,12 @@ func dirToURI(dir string) string {
 	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}).String()
 }
 
-// uriToDir converts a file:// URI back to a local directory path.
-func uriToDir(uri string) (string, error) {
-	return fileURIToPath(uri)
-}
-
 // canonicalRootURI resolves a client-provided local file URI to the canonical
 // absolute file URI we use as the server's internal root identity. Equivalent
 // aliases such as file:///repo and file://localhost/repo collapse to the same
 // canonical URI and directory.
 func canonicalRootURI(raw string) (string, string, error) {
-	dir, err := uriToDir(raw)
+	dir, err := fileURIToPath(raw)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/taskfileserver/roots_test.go
+++ b/internal/taskfileserver/roots_test.go
@@ -46,16 +46,16 @@ func TestDirToURI(t *testing.T) {
 		t.Fatalf("dirToURI(%q) returned unescaped URI %q", dir, uri)
 	}
 
-	roundTrip, err := uriToDir(uri)
+	roundTrip, err := fileURIToPath(uri)
 	if err != nil {
-		t.Fatalf("uriToDir(%q) failed: %v", uri, err)
+		t.Fatalf("fileURIToPath(%q) failed: %v", uri, err)
 	}
 	if roundTrip != filepath.Clean(dir) {
 		t.Errorf("uri round-trip = %q, want %q", roundTrip, filepath.Clean(dir))
 	}
 }
 
-func TestURIToDir(t *testing.T) {
+func TestFileURIToPath(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "path with #hash and ?query")
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		t.Fatal(err)
@@ -95,21 +95,21 @@ func TestURIToDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := uriToDir(tt.uri)
+			got, err := fileURIToPath(tt.uri)
 			if tt.wantErr != "" {
 				if err == nil {
-					t.Fatalf("uriToDir(%q) = %q, want error containing %q", tt.uri, got, tt.wantErr)
+					t.Fatalf("fileURIToPath(%q) = %q, want error containing %q", tt.uri, got, tt.wantErr)
 				}
 				if !strings.Contains(err.Error(), tt.wantErr) {
-					t.Fatalf("uriToDir(%q) error = %q, want substring %q", tt.uri, err, tt.wantErr)
+					t.Fatalf("fileURIToPath(%q) error = %q, want substring %q", tt.uri, err, tt.wantErr)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("uriToDir(%q) failed: %v", tt.uri, err)
+				t.Fatalf("fileURIToPath(%q) failed: %v", tt.uri, err)
 			}
 			if got != tt.want {
-				t.Fatalf("uriToDir(%q) = %q, want %q", tt.uri, got, tt.want)
+				t.Fatalf("fileURIToPath(%q) = %q, want %q", tt.uri, got, tt.want)
 			}
 		})
 	}

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -19,10 +19,9 @@ func New() *Server {
 	}
 }
 
-// SetMCPServer attaches the live MCP server instance used for tool updates.
-func (s *Server) SetMCPServer(server *mcp.Server) {
-	s.mcpServer = server
-	s.toolRegistry = server
+// SetToolRegistry attaches the registry used for tool registration updates.
+func (s *Server) SetToolRegistry(registry toolRegistry) {
+	s.toolRegistry = registry
 }
 
 // isMethodNotFound reports whether err is a JSON-RPC "method not found" error,

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -25,7 +25,6 @@ type toolRegistry interface {
 // Server represents our MCP server for Taskfile.yml.
 type Server struct {
 	roots           map[string]*Root
-	mcpServer       *mcp.Server
 	toolRegistry    toolRegistry
 	registeredTools map[string]mcp.Tool
 	mu              sync.Mutex
@@ -66,12 +65,6 @@ func (s *Server) snapshotToolStateLocked() toolStateSnapshot {
 		}
 	}
 	return snap
-}
-
-// rootSnapshot is a canonical root URI captured under lock for use by
-// watchTaskfiles without holding the mutex.
-type rootSnapshot struct {
-	uri string
 }
 
 // cloneStringSet returns a shallow copy of a string set.

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -62,7 +62,6 @@ func newTestServer(t *testing.T, fixture string) *Server {
 	t.Helper()
 	s := loadServerFromFixture(t, fixture)
 	mcpSrv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
-	s.mcpServer = mcpSrv
 	s.toolRegistry = mcpSrv
 	s.registeredTools = make(map[string]mcp.Tool)
 	return s
@@ -127,13 +126,13 @@ func snapshotFromServer(s *Server) toolStateSnapshot {
 	return snap
 }
 
-// snapshotRoots returns a rootSnapshot slice for use with watchTaskfiles.
-func snapshotRoots(s *Server) []rootSnapshot {
-	snap := make([]rootSnapshot, 0, len(s.roots))
+// snapshotRoots returns a slice of root URIs for use with watchTaskfiles.
+func snapshotRoots(s *Server) []string {
+	uris := make([]string, 0, len(s.roots))
 	for uri := range s.roots {
-		snap = append(snap, rootSnapshot{uri: uri})
+		uris = append(uris, uri)
 	}
-	return snap
+	return uris
 }
 
 // newTempServer creates a Server backed by a temp directory containing
@@ -159,7 +158,6 @@ func newServerForDir(t *testing.T, dir string) *Server {
 	mcpSrv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
 	s := &Server{
 		roots:           map[string]*Root{uri: root},
-		mcpServer:       mcpSrv,
 		toolRegistry:    mcpSrv,
 		registeredTools: make(map[string]mcp.Tool),
 	}

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -817,7 +817,6 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 	uri := dirToURI(dir)
 	s := &Server{
 		roots:           map[string]*Root{uri: root},
-		mcpServer:       mcpSrv,
 		toolRegistry:    tracker,
 		registeredTools: make(map[string]mcp.Tool),
 	}

--- a/internal/taskfileserver/watch.go
+++ b/internal/taskfileserver/watch.go
@@ -129,16 +129,16 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 	}
 }
 
-// watchTaskfiles starts file watchers for the given roots and blocks until the
-// context is cancelled. The caller must provide a snapshot captured under lock.
-func (s *Server) watchTaskfiles(ctx context.Context, roots []rootSnapshot) error {
+// watchTaskfiles starts file watchers for the given root URIs and blocks until
+// the context is cancelled. The caller must provide URIs captured under lock.
+func (s *Server) watchTaskfiles(ctx context.Context, rootURIs []string) error {
 	var wg sync.WaitGroup
 	var firstErr error
 	var errOnce sync.Once
 
-	for _, rs := range roots {
+	for _, uri := range rootURIs {
 		wg.Go(func() {
-			if err := s.watchRootTaskfiles(ctx, rs.uri); err != nil {
+			if err := s.watchRootTaskfiles(ctx, uri); err != nil {
 				errOnce.Do(func() { firstErr = err })
 			}
 		})
@@ -187,10 +187,10 @@ func (s *Server) restartWatchers(ctx context.Context) {
 	prevCancel := s.watchCancel
 	prevDone := s.watchDone
 
-	// Snapshot roots while we hold the lock.
-	snap := make([]rootSnapshot, 0, len(s.roots))
+	// Snapshot root URIs while we hold the lock.
+	rootURIs := make([]string, 0, len(s.roots))
 	for uri := range s.roots {
-		snap = append(snap, rootSnapshot{uri: uri})
+		rootURIs = append(rootURIs, uri)
 	}
 
 	// Prepare the new watcher generation before releasing the lock.
@@ -211,7 +211,7 @@ func (s *Server) restartWatchers(ctx context.Context) {
 
 	go func() {
 		defer close(done)
-		if err := s.watchTaskfiles(watchCtx, snap); err != nil {
+		if err := s.watchTaskfiles(watchCtx, rootURIs); err != nil {
 			log.Printf("file watcher failed: %v", err)
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func run() error {
 			RootsListChangedHandler: taskfileServer.HandleRootsChanged,
 		},
 	)
-	taskfileServer.SetMCPServer(mcpServer)
+	taskfileServer.SetToolRegistry(mcpServer)
 
 	// Start the stdio server
 	if err := mcpServer.Run(ctx, &mcp.StdioTransport{}); err != nil {


### PR DESCRIPTION
Phase 1 cleanup from the post-review refinement plan. Removes state on `Server` that was assigned but never read, and trims small one-shot helpers/types that obscured the surface area without earning their keep. Pure refactor with no behaviour change.

- Drop the unused `Server.mcpServer` field; only `toolRegistry` is consumed.
- Rename `SetMCPServer` to `SetToolRegistry` and accept the `toolRegistry` interface directly. `main.go` still wires the registry before `mcpServer.Run`, so `InitializedHandler` / `RootsListChangedHandler` continue to fire after the registry is in place.
- Inline the one-line `uriToDir` shim into its sole caller in `roots.go`; tests now exercise `fileURIToPath` directly.
- Replace the single-field `rootSnapshot` struct with a plain `[]string` of root URIs in `watchTaskfiles`/`restartWatchers` and the test helpers.

Verified with `task ci` (lint + test) and `task build`.

Closes #81