### PR TITLE
chore(taskfileserver): small cleanups

### DIFF
--- a/internal/taskfileserver/integration_test.go
+++ b/internal/taskfileserver/integration_test.go
@@ -31,7 +31,7 @@ func TestHandleInitialized_WithRoots(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -98,7 +98,7 @@ func TestHandleInitialized_CallToolExecutesSingleRootTool(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -152,7 +152,7 @@ func TestHandleInitialized_DeduplicatesEquivalentRootURIs(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -213,7 +213,7 @@ func TestHandleRootsChanged_AddAndRemove(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -279,7 +279,7 @@ func TestHandleRootsChanged_EquivalentURIAliasKeepsSingleRoot(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -365,7 +365,7 @@ func TestHandleInitialized_NoPublicTasks(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -419,7 +419,7 @@ func TestHandleRootsChanged_TransitionToUnprefixed(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -487,7 +487,7 @@ func TestHandleRootsChanged_TransitionToUnprefixedCallTool(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -547,7 +547,7 @@ func TestHandleRootsChanged_RemoveLastRootClearsTools(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)
@@ -609,7 +609,7 @@ func TestToolListChangedNotification_OnFileChange(t *testing.T) {
 		RootsListChangedHandler: ts.HandleRootsChanged,
 	})
 	ts.toolRegistry = server
-	ts.registeredTools = make(map[string]mcp.Tool)
+	ts.registeredTools = make(map[string]registeredTool)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := server.Connect(ctx, st, nil)

--- a/internal/taskfileserver/roots.go
+++ b/internal/taskfileserver/roots.go
@@ -144,11 +144,17 @@ func (s *Server) unloadRoot(uri string) {
 	delete(s.roots, uri)
 }
 
-// disableRootToolsLocked clears the loaded Taskfile state for a root and
-// bumps the generation. The caller must hold s.mu. The actual MCP sync
-// is performed by the caller after releasing the lock.
-func (s *Server) disableRootToolsLocked(root *Root) {
-	root.taskfile = nil
+// disableRootToolsLocked replaces the root at uri with a fresh *Root that
+// preserves the workdir and watcher set but has no loaded Taskfile, then
+// bumps the generation. Replacing rather than mutating keeps Root values
+// reachable from prior snapshots effectively immutable. The caller must
+// hold s.mu and is responsible for running syncTools afterwards.
+func (s *Server) disableRootToolsLocked(uri string, root *Root) {
+	s.roots[uri] = &Root{
+		workdir:        root.workdir,
+		watchDirs:      root.watchDirs,
+		watchTaskfiles: root.watchTaskfiles,
+	}
 	s.generation++
 }
 
@@ -167,7 +173,7 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, workdir)
 	if err != nil {
 		s.mu.Lock()
-		s.disableRootToolsLocked(root)
+		s.disableRootToolsLocked(uri, root)
 		s.mu.Unlock()
 		syncErr := s.syncTools()
 		if syncErr != nil {
@@ -183,7 +189,7 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 	)
 	if err := executor.Setup(); err != nil {
 		s.mu.Lock()
-		s.disableRootToolsLocked(root)
+		s.disableRootToolsLocked(uri, root)
 		s.mu.Unlock()
 		syncErr := s.syncTools()
 		if syncErr != nil {
@@ -193,9 +199,12 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 	}
 
 	s.mu.Lock()
-	root.taskfile = executor.Taskfile
-	root.watchDirs = watchDirs
-	root.watchTaskfiles = watchTaskfiles
+	s.roots[uri] = &Root{
+		taskfile:       executor.Taskfile,
+		workdir:        workdir,
+		watchDirs:      watchDirs,
+		watchTaskfiles: watchTaskfiles,
+	}
 	s.generation++
 	s.mu.Unlock()
 

--- a/internal/taskfileserver/roots.go
+++ b/internal/taskfileserver/roots.go
@@ -80,6 +80,32 @@ func isWindowsDriveURIPath(path string) bool {
 	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
 }
 
+// buildRoot resolves the Taskfile graph for workdir, sets up a task
+// executor, and returns a fully populated *Root. workdir must already be
+// an absolute path.
+func buildRoot(ctx context.Context, workdir string) (*Root, error) {
+	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, workdir)
+	if err != nil {
+		return nil, err
+	}
+
+	executor := task.NewExecutor(
+		task.WithDir(workdir),
+		task.WithEntrypoint(entrypoint),
+		task.WithSilent(true),
+	)
+	if err := executor.Setup(); err != nil {
+		return nil, fmt.Errorf("failed to setup task executor for %s: %w", workdir, err)
+	}
+
+	return &Root{
+		taskfile:       executor.Taskfile,
+		workdir:        workdir,
+		watchDirs:      watchDirs,
+		watchTaskfiles: watchTaskfiles,
+	}, nil
+}
+
 // loadRoot creates a new Root by loading the Taskfile from the given directory.
 func loadRoot(ctx context.Context, dir string) (*Root, error) {
 	abs, err := filepath.Abs(dir)
@@ -87,27 +113,7 @@ func loadRoot(ctx context.Context, dir string) (*Root, error) {
 		return nil, fmt.Errorf("failed to resolve path: %w", err)
 	}
 
-	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, abs)
-	if err != nil {
-		return nil, err
-	}
-
-	executor := task.NewExecutor(
-		task.WithDir(abs),
-		task.WithEntrypoint(entrypoint),
-		task.WithSilent(true),
-	)
-
-	if err := executor.Setup(); err != nil {
-		return nil, fmt.Errorf("failed to setup task executor for %s: %w", abs, err)
-	}
-
-	return &Root{
-		taskfile:       executor.Taskfile,
-		workdir:        abs,
-		watchDirs:      watchDirs,
-		watchTaskfiles: watchTaskfiles,
-	}, nil
+	return buildRoot(ctx, abs)
 }
 
 // newUnloadedRoot creates a root placeholder for a workspace that does not yet
@@ -170,7 +176,7 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 	workdir := root.workdir
 	s.mu.Unlock()
 
-	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, workdir)
+	newRoot, err := buildRoot(ctx, workdir)
 	if err != nil {
 		s.mu.Lock()
 		s.disableRootToolsLocked(uri, root)
@@ -182,29 +188,8 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 		return fmt.Errorf("failed to reload root %s: %w", uri, err)
 	}
 
-	executor := task.NewExecutor(
-		task.WithDir(workdir),
-		task.WithEntrypoint(entrypoint),
-		task.WithSilent(true),
-	)
-	if err := executor.Setup(); err != nil {
-		s.mu.Lock()
-		s.disableRootToolsLocked(uri, root)
-		s.mu.Unlock()
-		syncErr := s.syncTools()
-		if syncErr != nil {
-			return fmt.Errorf("failed to setup task executor for %s: %w", workdir, errors.Join(err, fmt.Errorf("failed to clear stale tools: %w", syncErr)))
-		}
-		return fmt.Errorf("failed to setup task executor for %s: %w", workdir, err)
-	}
-
 	s.mu.Lock()
-	s.roots[uri] = &Root{
-		taskfile:       executor.Taskfile,
-		workdir:        workdir,
-		watchDirs:      watchDirs,
-		watchTaskfiles: watchTaskfiles,
-	}
+	s.roots[uri] = newRoot
 	s.generation++
 	s.mu.Unlock()
 

--- a/internal/taskfileserver/roots_test.go
+++ b/internal/taskfileserver/roots_test.go
@@ -4,9 +4,18 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/go-task/task/v3/taskfile"
 )
+
+// isTaskfile reports whether the given path's basename matches one of the
+// supported Taskfile filenames from taskfile.DefaultTaskfiles.
+func isTaskfile(path string) bool {
+	return slices.Contains(taskfile.DefaultTaskfiles, filepath.Base(path))
+}
 
 func TestIsTaskfile(t *testing.T) {
 	tests := []struct {

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -15,7 +15,7 @@ import (
 func New() *Server {
 	return &Server{
 		roots:           make(map[string]*Root),
-		registeredTools: make(map[string]mcp.Tool),
+		registeredTools: make(map[string]registeredTool),
 	}
 }
 

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -8,7 +8,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Root holds the loaded per-root Taskfile data.
+// Root holds the loaded per-root Taskfile data. Once a *Root is published
+// into Server.roots its fields are treated as read-only; mutations are
+// performed by replacing the pointer in the map rather than writing
+// through the existing value, so concurrent readers (snapshots, watchers)
+// always observe a consistent state.
 type Root struct {
 	taskfile       *ast.Taskfile
 	workdir        string

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -66,17 +66,3 @@ func (s *Server) snapshotToolStateLocked() toolStateSnapshot {
 	}
 	return snap
 }
-
-// cloneStringSet returns a shallow copy of a string set.
-func cloneStringSet(values map[string]struct{}) map[string]struct{} {
-	cloned := make(map[string]struct{}, len(values))
-	for value := range values {
-		cloned[value] = struct{}{}
-	}
-	return cloned
-}
-
-// cloneStrings returns a copy of a string slice.
-func cloneStrings(values []string) []string {
-	return append([]string(nil), values...)
-}

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -26,7 +26,7 @@ type toolRegistry interface {
 type Server struct {
 	roots           map[string]*Root
 	toolRegistry    toolRegistry
-	registeredTools map[string]mcp.Tool
+	registeredTools map[string]registeredTool
 	mu              sync.Mutex
 	generation      uint64
 	watchCancel     context.CancelFunc

--- a/internal/taskfileserver/taskgraph.go
+++ b/internal/taskfileserver/taskgraph.go
@@ -110,9 +110,3 @@ func sortedKeys(values map[string]struct{}) []string {
 	slices.Sort(keys)
 	return keys
 }
-
-// isTaskfile reports whether the given path's basename matches one of the
-// supported Taskfile filenames from taskfile.DefaultTaskfiles.
-func isTaskfile(path string) bool {
-	return slices.Contains(taskfile.DefaultTaskfiles, filepath.Base(path))
-}

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -63,13 +63,13 @@ func newTestServer(t *testing.T, fixture string) *Server {
 	s := loadServerFromFixture(t, fixture)
 	mcpSrv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
 	s.toolRegistry = mcpSrv
-	s.registeredTools = make(map[string]mcp.Tool)
+	s.registeredTools = make(map[string]registeredTool)
 	return s
 }
 
 // schemaProperties marshals a tool's InputSchema to JSON, then unmarshals it
 // to return the properties map. This handles InputSchema being any (e.g. json.RawMessage).
-func schemaProperties(t *testing.T, tool *mcp.Tool) map[string]any {
+func schemaProperties(t *testing.T, tool *registeredTool) map[string]any {
 	t.Helper()
 
 	b, err := json.Marshal(tool.InputSchema)
@@ -101,7 +101,7 @@ func lookupTask(t *testing.T, tf *ast.Taskfile, name string) *ast.Task {
 }
 
 // toolNames returns the sorted keys from a tool map for use in error messages.
-func toolNames(tools map[string]mcp.Tool) []string {
+func toolNames[V any](tools map[string]V) []string {
 	names := make([]string, 0, len(tools))
 	for name := range tools {
 		names = append(names, name)
@@ -159,7 +159,7 @@ func newServerForDir(t *testing.T, dir string) *Server {
 	s := &Server{
 		roots:           map[string]*Root{uri: root},
 		toolRegistry:    mcpSrv,
-		registeredTools: make(map[string]mcp.Tool),
+		registeredTools: make(map[string]registeredTool),
 	}
 	if err := s.syncTools(); err != nil {
 		t.Fatalf("initial syncTools: %v", err)
@@ -168,7 +168,7 @@ func newServerForDir(t *testing.T, dir string) *Server {
 }
 
 // schemaRequired extracts the "required" array from a tool's InputSchema.
-func schemaRequired(t *testing.T, tool *mcp.Tool) []string {
+func schemaRequired(t *testing.T, tool *registeredTool) []string {
 	t.Helper()
 
 	b, err := json.Marshal(tool.InputSchema)

--- a/internal/taskfileserver/tools.go
+++ b/internal/taskfileserver/tools.go
@@ -13,13 +13,22 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// registeredTool wraps an mcp.Tool with its serialized InputSchema bytes
+// so equality checks can compare schemas as raw bytes without
+// re-marshalling on every diff. The mcp.Tool is embedded so callers can
+// continue to access Name, Description, and InputSchema directly.
+type registeredTool struct {
+	mcp.Tool
+	schemaBytes []byte
+}
+
 // createToolForTask creates an MCP tool definition for a given task.
 // The tool name is sanitized for MCP compatibility; the description
 // references the original Taskfile task name for clarity. The prefix
 // parameter is used in multi-root mode to namespace tool names. The
 // taskfile is taken by value rather than via *Root so the planner can
 // run on a snapshot without touching live, mutable server state.
-func createToolForTask(tf *ast.Taskfile, prefix, taskName string, taskDef *ast.Task) *mcp.Tool {
+func createToolForTask(tf *ast.Taskfile, prefix, taskName string, taskDef *ast.Task) *registeredTool {
 	toolName := sanitizeToolName(prefixedToolName(prefix, taskName))
 
 	description := taskDef.Desc
@@ -85,15 +94,18 @@ func createToolForTask(tf *ast.Taskfile, prefix, taskName string, taskDef *ast.T
 		schema = []byte(`{"type":"object"}`)
 	}
 
-	return &mcp.Tool{
-		Name:        toolName,
-		Description: description,
-		InputSchema: json.RawMessage(schema),
+	return &registeredTool{
+		Tool: mcp.Tool{
+			Name:        toolName,
+			Description: description,
+			InputSchema: json.RawMessage(schema),
+		},
+		schemaBytes: schema,
 	}
 }
 
 type toolPlan struct {
-	tools    map[string]mcp.Tool
+	tools    map[string]registeredTool
 	handlers map[string]mcp.ToolHandler
 }
 
@@ -103,12 +115,12 @@ func buildToolPlan(snap toolStateSnapshot) toolPlan {
 	type toolCandidate struct {
 		workdir  string
 		taskName string
-		tool     mcp.Tool
+		tool     registeredTool
 		handler  mcp.ToolHandler
 	}
 
 	plan := toolPlan{
-		tools:    make(map[string]mcp.Tool),
+		tools:    make(map[string]registeredTool),
 		handlers: make(map[string]mcp.ToolHandler),
 	}
 	candidates := make(map[string][]toolCandidate)
@@ -161,26 +173,18 @@ func buildToolPlan(snap toolStateSnapshot) toolPlan {
 	return plan
 }
 
-// toolsEqual reports whether two tool definitions are equivalent
-// by comparing Name, Description, and InputSchema bytes.
-func toolsEqual(a, b *mcp.Tool) bool {
-	if a.Name != b.Name || a.Description != b.Description {
-		return false
-	}
-	aSchema, err := json.Marshal(a.InputSchema)
-	if err != nil {
-		return false
-	}
-	bSchema, err := json.Marshal(b.InputSchema)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(aSchema, bSchema)
+// toolsEqual reports whether two registered tools are equivalent by
+// comparing Name, Description, and the cached InputSchema bytes captured
+// when the tool was created.
+func toolsEqual(a, b *registeredTool) bool {
+	return a.Name == b.Name &&
+		a.Description == b.Description &&
+		bytes.Equal(a.schemaBytes, b.schemaBytes)
 }
 
 // diffTools compares the old registered tool set against the desired set and
 // returns the names of tools to remove and tools to add (or re-add due to changes).
-func diffTools(old, desired map[string]mcp.Tool) (stale, added []string) {
+func diffTools(old, desired map[string]registeredTool) (stale, added []string) {
 	for name, oldTool := range old {
 		if newTool, ok := desired[name]; !ok {
 			stale = append(stale, name)
@@ -206,7 +210,7 @@ func (s *Server) syncTools() error {
 	// Phase 1: snapshot under lock.
 	s.mu.Lock()
 	snap := s.snapshotToolStateLocked()
-	oldTools := make(map[string]mcp.Tool, len(s.registeredTools))
+	oldTools := make(map[string]registeredTool, len(s.registeredTools))
 	maps.Copy(oldTools, s.registeredTools)
 	s.mu.Unlock()
 
@@ -226,7 +230,7 @@ func (s *Server) syncTools() error {
 	}
 	for _, name := range added {
 		t := plan.tools[name]
-		s.toolRegistry.AddTool(&t, plan.handlers[name])
+		s.toolRegistry.AddTool(&t.Tool, plan.handlers[name])
 	}
 	s.registeredTools = plan.tools
 	return nil

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -470,33 +470,40 @@ func TestToolsEqual(t *testing.T) {
 	schema1 := json.RawMessage(`{"type":"object","properties":{"FOO":{"type":"string"}}}`)
 	schema2 := json.RawMessage(`{"type":"object","properties":{"BAR":{"type":"string"}}}`)
 
+	mk := func(name, desc string, schema json.RawMessage) *registeredTool {
+		return &registeredTool{
+			Tool:        mcp.Tool{Name: name, Description: desc, InputSchema: schema},
+			schemaBytes: schema,
+		}
+	}
+
 	tests := []struct {
 		name string
-		a, b *mcp.Tool
+		a, b *registeredTool
 		want bool
 	}{
 		{
 			name: "identical",
-			a:    &mcp.Tool{Name: "greet", Description: "Say hello", InputSchema: schema1},
-			b:    &mcp.Tool{Name: "greet", Description: "Say hello", InputSchema: schema1},
+			a:    mk("greet", "Say hello", schema1),
+			b:    mk("greet", "Say hello", schema1),
 			want: true,
 		},
 		{
 			name: "different name",
-			a:    &mcp.Tool{Name: "greet", Description: "Say hello", InputSchema: schema1},
-			b:    &mcp.Tool{Name: "build", Description: "Say hello", InputSchema: schema1},
+			a:    mk("greet", "Say hello", schema1),
+			b:    mk("build", "Say hello", schema1),
 			want: false,
 		},
 		{
 			name: "different description",
-			a:    &mcp.Tool{Name: "greet", Description: "Say hello", InputSchema: schema1},
-			b:    &mcp.Tool{Name: "greet", Description: "Say goodbye", InputSchema: schema1},
+			a:    mk("greet", "Say hello", schema1),
+			b:    mk("greet", "Say goodbye", schema1),
 			want: false,
 		},
 		{
 			name: "different schema",
-			a:    &mcp.Tool{Name: "greet", Description: "Say hello", InputSchema: schema1},
-			b:    &mcp.Tool{Name: "greet", Description: "Say hello", InputSchema: schema2},
+			a:    mk("greet", "Say hello", schema1),
+			b:    mk("greet", "Say hello", schema2),
 			want: false,
 		},
 	}
@@ -517,7 +524,7 @@ func TestSyncTools_Idempotent(t *testing.T) {
 	if err := s.syncTools(); err != nil {
 		t.Fatalf("first syncTools failed: %v", err)
 	}
-	first := make(map[string]mcp.Tool)
+	first := make(map[string]registeredTool)
 	maps.Copy(first, s.registeredTools)
 
 	if err := s.syncTools(); err != nil {
@@ -680,11 +687,15 @@ func TestCreateToolForTask_WithPrefix_EnforcesMaxLength(t *testing.T) {
 
 func TestDiffTools(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object"}`)
+	mk := func(name, desc string) registeredTool {
+		return registeredTool{
+			Tool:        mcp.Tool{Name: name, Description: desc, InputSchema: schema},
+			schemaBytes: schema,
+		}
+	}
 
 	t.Run("empty to populated", func(t *testing.T) {
-		desired := map[string]mcp.Tool{
-			"greet": {Name: "greet", Description: "Say hello", InputSchema: schema},
-		}
+		desired := map[string]registeredTool{"greet": mk("greet", "Say hello")}
 		stale, added := diffTools(nil, desired)
 		if len(stale) != 0 {
 			t.Errorf("stale = %v, want empty", stale)
@@ -695,9 +706,7 @@ func TestDiffTools(t *testing.T) {
 	})
 
 	t.Run("populated to empty", func(t *testing.T) {
-		old := map[string]mcp.Tool{
-			"greet": {Name: "greet", Description: "Say hello", InputSchema: schema},
-		}
+		old := map[string]registeredTool{"greet": mk("greet", "Say hello")}
 		stale, added := diffTools(old, nil)
 		if !slices.Equal(stale, []string{"greet"}) {
 			t.Errorf("stale = %v, want [greet]", stale)
@@ -708,9 +717,7 @@ func TestDiffTools(t *testing.T) {
 	})
 
 	t.Run("unchanged", func(t *testing.T) {
-		tools := map[string]mcp.Tool{
-			"greet": {Name: "greet", Description: "Say hello", InputSchema: schema},
-		}
+		tools := map[string]registeredTool{"greet": mk("greet", "Say hello")}
 		stale, added := diffTools(tools, tools)
 		if len(stale) != 0 {
 			t.Errorf("stale = %v, want empty", stale)
@@ -721,12 +728,8 @@ func TestDiffTools(t *testing.T) {
 	})
 
 	t.Run("changed description", func(t *testing.T) {
-		old := map[string]mcp.Tool{
-			"greet": {Name: "greet", Description: "Say hello", InputSchema: schema},
-		}
-		desired := map[string]mcp.Tool{
-			"greet": {Name: "greet", Description: "Say goodbye", InputSchema: schema},
-		}
+		old := map[string]registeredTool{"greet": mk("greet", "Say hello")}
+		desired := map[string]registeredTool{"greet": mk("greet", "Say goodbye")}
 		stale, added := diffTools(old, desired)
 		if !slices.Equal(stale, []string{"greet"}) {
 			t.Errorf("stale = %v, want [greet]", stale)
@@ -769,7 +772,7 @@ func TestSyncTools_DiscardsOnGenerationMismatch(t *testing.T) {
 
 	s.mu.Lock()
 	initialGen := s.generation
-	initialTools := make(map[string]mcp.Tool)
+	initialTools := make(map[string]registeredTool)
 	maps.Copy(initialTools, s.registeredTools)
 
 	// Simulate a concurrent mutation by bumping the generation while
@@ -818,7 +821,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 	s := &Server{
 		roots:           map[string]*Root{uri: root},
 		toolRegistry:    tracker,
-		registeredTools: make(map[string]mcp.Tool),
+		registeredTools: make(map[string]registeredTool),
 	}
 
 	// Initial sync registers both tools.
@@ -834,7 +837,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 
 	// Reset registeredTools so the next sync will try to re-add both.
 	s.mu.Lock()
-	s.registeredTools = make(map[string]mcp.Tool)
+	s.registeredTools = make(map[string]registeredTool)
 	s.generation++
 	s.mu.Unlock()
 
@@ -860,7 +863,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 	// G1: snapshot with both tasks, then mutate state before G1 applies.
 	s.mu.Lock()
 	snap := s.snapshotToolStateLocked()
-	oldTools := make(map[string]mcp.Tool, len(s.registeredTools))
+	oldTools := make(map[string]registeredTool, len(s.registeredTools))
 	maps.Copy(oldTools, s.registeredTools)
 
 	// Simulate concurrent mutation while G1 is "planning".
@@ -886,7 +889,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 		}
 		for _, name := range added {
 			tool := plan.tools[name]
-			s.toolRegistry.AddTool(&tool, plan.handlers[name])
+			s.toolRegistry.AddTool(&tool.Tool, plan.handlers[name])
 		}
 		s.registeredTools = plan.tools
 		s.mu.Unlock()
@@ -899,7 +902,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 
 	// registeredTools should have {taskA} only.
 	s.mu.Lock()
-	regTools := make(map[string]mcp.Tool)
+	regTools := make(map[string]registeredTool)
 	maps.Copy(regTools, s.registeredTools)
 	s.mu.Unlock()
 

--- a/internal/taskfileserver/watch.go
+++ b/internal/taskfileserver/watch.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -21,7 +23,7 @@ func (s *Server) rootWatchState(uri string) ([]string, map[string]struct{}, bool
 		return nil, nil, false
 	}
 
-	return cloneStrings(root.watchDirs), cloneStringSet(root.watchTaskfiles), true
+	return slices.Clone(root.watchDirs), maps.Clone(root.watchTaskfiles), true
 }
 
 // syncWatcherDirs ensures the fsnotify watcher is subscribed to the provided


### PR DESCRIPTION
Addresses the grab-bag of small refinements tracked in #90, each as a focused commit so they can be reviewed independently. The changes tighten the package without altering its observable behaviour: dead/test-only helpers are moved out of production code, bespoke clone helpers are replaced with stdlib equivalents, schema marshalling is cached on the diff hot path, and the per-root state is made effectively immutable.

- Move `isTaskfile` to its only consumer (`roots_test.go`) so it stops shipping in production
- Replace `cloneStrings`/`cloneStringSet` with `slices.Clone` and `maps.Clone`
- Cache marshalled `InputSchema` bytes in a new `registeredTool` wrapper so `toolsEqual` is a single `bytes.Equal` instead of two `json.Marshal` calls per diff entry
- Make `Root` effectively immutable: `disableRootToolsLocked` and `reloadRoot` publish a fresh `*Root` rather than mutating fields in place, with the contract documented on the type
- Extract a `buildRoot(ctx, workdir)` helper shared by `loadRoot` and `reloadRoot` to remove the duplicated `loadTaskfileWatchSet` → `NewExecutor` → `Setup` pipeline

Closes #90