### PR TITLE
feat(tools)!: use array shape for wildcard MATCH parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,23 +96,25 @@ The prefix is derived from the directory basename with non-alphanumeric characte
 
 ### Wildcard Tasks
 
-Taskfile [wildcard tasks](https://taskfile.dev/docs/guide#wildcard-arguments) (e.g. `start:*`) are exposed as tools with a required `MATCH` parameter. The server reconstructs the full task name at invocation time.
+Taskfile [wildcard tasks](https://taskfile.dev/docs/guide#wildcard-arguments) (e.g. `start:*`) are exposed as tools with a required `MATCH` parameter. `MATCH` is a JSON array of strings with one entry per `*` segment in the task name; the schema sets `minItems` and `maxItems` to that count so wrong-arity calls fail validation before the handler runs. The server substitutes each entry into the corresponding `*` segment to reconstruct the full task name at invocation time.
 
 For a task defined as `start:*`, calling the tool:
 
 ```json
-{"name": "start", "arguments": {"MATCH": "web"}}
+{"name": "start", "arguments": {"MATCH": ["web"]}}
 ```
 
 executes `task start:web`.
 
-For tasks with multiple wildcards (e.g. `deploy:*:*`), provide exactly one comma-separated value per wildcard segment. Surrounding whitespace is trimmed, but empty segments are rejected:
+For tasks with multiple wildcards (e.g. `deploy:*:*`), provide one array element per wildcard segment, in order. Empty strings are rejected:
 
 ```json
-{"name": "deploy", "arguments": {"MATCH": "api,production"}}
+{"name": "deploy", "arguments": {"MATCH": ["api", "production"]}}
 ```
 
 executes `task deploy:api:production`.
+
+> **Breaking change**: previous releases accepted `MATCH` as a single comma-separated string (e.g. `"api,production"`). Update clients to send a JSON array of strings instead. Values may now safely contain commas.
 
 ## MCP Integration
 

--- a/internal/taskfileserver/execute.go
+++ b/internal/taskfileserver/execute.go
@@ -33,33 +33,44 @@ func createTaskHandlerForWorkdir(workdir, taskName string) mcp.ToolHandler {
 		// Resolve the actual task name, substituting wildcards from MATCH
 		resolvedName := taskName
 		if wildcard {
-			matchVal, ok := arguments["MATCH"].(string)
-			if !ok || matchVal == "" {
+			rawMatch, ok := arguments["MATCH"]
+			if !ok {
 				return &mcp.CallToolResult{
 					Content: []mcp.Content{&mcp.TextContent{Text: "MATCH argument is required for wildcard tasks"}},
 					IsError: true,
 				}, nil
 			}
-			parts := strings.Split(matchVal, ",")
-			if len(parts) != wildcardCount {
+			rawParts, ok := rawMatch.([]any)
+			if !ok {
 				return &mcp.CallToolResult{
-					Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("MATCH requires exactly %d comma-separated value(s), got %d", wildcardCount, len(parts))}},
+					Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("MATCH must be an array of strings, got %T", rawMatch)}},
 					IsError: true,
 				}, nil
 			}
-			trimmedParts := make([]string, 0, len(parts))
-			for i, p := range parts {
-				trimmed := strings.TrimSpace(p)
-				if trimmed == "" {
+			if len(rawParts) != wildcardCount {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("MATCH requires exactly %d value(s), got %d", wildcardCount, len(rawParts))}},
+					IsError: true,
+				}, nil
+			}
+			parts := make([]string, 0, len(rawParts))
+			for i, raw := range rawParts {
+				str, ok := raw.(string)
+				if !ok {
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("MATCH value %d must be a string, got %T", i+1, raw)}},
+						IsError: true,
+					}, nil
+				}
+				if str == "" {
 					return &mcp.CallToolResult{
 						Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("MATCH value %d cannot be empty", i+1)}},
 						IsError: true,
 					}, nil
 				}
-				trimmedParts = append(trimmedParts, trimmed)
+				parts = append(parts, str)
 			}
-			resolvedName = taskName
-			for _, p := range trimmedParts {
+			for _, p := range parts {
 				resolvedName = strings.Replace(resolvedName, "*", p, 1)
 			}
 			delete(arguments, "MATCH")

--- a/internal/taskfileserver/execute_test.go
+++ b/internal/taskfileserver/execute_test.go
@@ -16,7 +16,7 @@ func TestCreateTaskHandlerForWorkdir_WildcardMATCH(t *testing.T) {
 		name        string
 		taskName    string
 		toolName    string
-		arguments   map[string]string
+		arguments   map[string]any
 		wantError   bool
 		wantSubstrs []string
 	}{
@@ -24,15 +24,22 @@ func TestCreateTaskHandlerForWorkdir_WildcardMATCH(t *testing.T) {
 			name:        "single wildcard success",
 			taskName:    "start:*",
 			toolName:    "start",
-			arguments:   map[string]string{"MATCH": "web"},
+			arguments:   map[string]any{"MATCH": []string{"web"}},
 			wantSubstrs: []string{"completed successfully", "web"},
 		},
 		{
-			name:        "multi wildcard trims values",
+			name:        "multi wildcard success",
 			taskName:    "deploy:*:*",
 			toolName:    "deploy",
-			arguments:   map[string]string{"MATCH": " api , production "},
+			arguments:   map[string]any{"MATCH": []string{"api", "production"}},
 			wantSubstrs: []string{"completed successfully", "api", "production"},
+		},
+		{
+			name:        "value containing comma is preserved",
+			taskName:    "start:*",
+			toolName:    "start",
+			arguments:   map[string]any{"MATCH": []string{"a,b"}},
+			wantSubstrs: []string{"completed successfully", "a,b"},
 		},
 		{
 			name:        "missing MATCH",
@@ -42,28 +49,44 @@ func TestCreateTaskHandlerForWorkdir_WildcardMATCH(t *testing.T) {
 			wantSubstrs: []string{"MATCH"},
 		},
 		{
-			name:        "wrong MATCH count",
+			name:        "MATCH not an array",
+			taskName:    "start:*",
+			toolName:    "start",
+			arguments:   map[string]any{"MATCH": "web"},
+			wantError:   true,
+			wantSubstrs: []string{"must be an array"},
+		},
+		{
+			name:        "too few MATCH values",
 			taskName:    "deploy:*:*",
 			toolName:    "deploy",
-			arguments:   map[string]string{"MATCH": "onlyone"},
+			arguments:   map[string]any{"MATCH": []string{"onlyone"}},
 			wantError:   true,
-			wantSubstrs: []string{"2 comma-separated"},
+			wantSubstrs: []string{"exactly 2 value(s)", "got 1"},
 		},
 		{
 			name:        "too many MATCH values",
 			taskName:    "deploy:*:*",
 			toolName:    "deploy",
-			arguments:   map[string]string{"MATCH": "api,production,extra"},
+			arguments:   map[string]any{"MATCH": []string{"api", "production", "extra"}},
 			wantError:   true,
-			wantSubstrs: []string{"exactly 2 comma-separated", "got 3"},
+			wantSubstrs: []string{"exactly 2 value(s)", "got 3"},
 		},
 		{
 			name:        "empty MATCH segment",
 			taskName:    "deploy:*:*",
 			toolName:    "deploy",
-			arguments:   map[string]string{"MATCH": "api, "},
+			arguments:   map[string]any{"MATCH": []string{"api", ""}},
 			wantError:   true,
 			wantSubstrs: []string{"cannot be empty"},
+		},
+		{
+			name:        "non-string MATCH element",
+			taskName:    "start:*",
+			toolName:    "start",
+			arguments:   map[string]any{"MATCH": []any{42}},
+			wantError:   true,
+			wantSubstrs: []string{"must be a string"},
 		},
 	}
 

--- a/internal/taskfileserver/tools.go
+++ b/internal/taskfileserver/tools.go
@@ -90,12 +90,12 @@ func createToolForTask(tf *ast.Taskfile, prefix, taskName string, taskDef *ast.T
 	// Add MATCH parameter for wildcard tasks
 	if isWildcardTask(taskName) {
 		n := countWildcards(taskName)
-		matchDesc := "Wildcard value for task pattern " + taskName
-		if n > 1 {
-			matchDesc += fmt.Sprintf(" (%d comma-separated values)", n)
-		}
+		matchDesc := fmt.Sprintf("Wildcard values for task pattern %s (%d value(s) required, one per '*' segment)", taskName, n)
 		properties["MATCH"] = map[string]any{
-			"type":        "string",
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"minItems":    n,
+			"maxItems":    n,
 			"description": matchDesc,
 		}
 		required = append(required, "MATCH")

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -329,8 +329,22 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 		}
 
 		props := schemaProperties(t, tool)
-		if _, ok := props["MATCH"]; !ok {
-			t.Fatal("missing MATCH property for wildcard task")
+		matchProp, ok := props["MATCH"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing MATCH property for wildcard task, got %v", props)
+		}
+		if got := matchProp["type"]; got != "array" {
+			t.Errorf("MATCH.type = %v, want %q", got, "array")
+		}
+		items, _ := matchProp["items"].(map[string]any)
+		if got := items["type"]; got != "string" {
+			t.Errorf("MATCH.items.type = %v, want %q", got, "string")
+		}
+		if got, want := matchProp["minItems"], float64(1); got != want {
+			t.Errorf("MATCH.minItems = %v, want %v", got, want)
+		}
+		if got, want := matchProp["maxItems"], float64(1); got != want {
+			t.Errorf("MATCH.maxItems = %v, want %v", got, want)
 		}
 
 		required := schemaRequired(t, tool)
@@ -348,14 +362,21 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 		}
 
 		props := schemaProperties(t, tool)
-		matchProp, ok := props["MATCH"]
+		matchProp, ok := props["MATCH"].(map[string]any)
 		if !ok {
-			t.Fatal("missing MATCH property for wildcard task")
+			t.Fatalf("missing MATCH property for wildcard task, got %v", props)
 		}
-
-		propMap, _ := matchProp.(map[string]any)
-		desc, _ := propMap["description"].(string)
-		if !strings.Contains(desc, "2 comma-separated") {
+		if got := matchProp["type"]; got != "array" {
+			t.Errorf("MATCH.type = %v, want %q", got, "array")
+		}
+		if got, want := matchProp["minItems"], float64(2); got != want {
+			t.Errorf("MATCH.minItems = %v, want %v", got, want)
+		}
+		if got, want := matchProp["maxItems"], float64(2); got != want {
+			t.Errorf("MATCH.maxItems = %v, want %v", got, want)
+		}
+		desc, _ := matchProp["description"].(string)
+		if !strings.Contains(desc, "2 value(s)") {
 			t.Errorf("MATCH description should mention 2 values, got %q", desc)
 		}
 	})
@@ -478,7 +499,7 @@ func TestBuildToolPlan_HandlerExecutesWildcardTool(t *testing.T) {
 		t.Fatalf("missing handler for deploy, got %v", toolNames(plan.tools))
 	}
 
-	result := callToolHandler(t, handler, "deploy", map[string]string{"MATCH": "api,production"})
+	result := callToolHandler(t, handler, "deploy", map[string]any{"MATCH": []string{"api", "production"}})
 	if result.IsError {
 		t.Fatalf("expected success, got IsError=true: %s", toolResultText(t, result))
 	}


### PR DESCRIPTION
Switch the wildcard `MATCH` parameter from a comma-separated string to a JSON array of strings, so wildcard values can safely contain commas and wrong-arity calls are rejected by JSON Schema validation before reaching the handler.

- Schema for wildcard tasks now declares `MATCH` as `{"type":"array","items":{"type":"string"},"minItems":N,"maxItems":N}` where `N = countWildcards(taskName)`, with `MATCH` still required.
- Handler reads `MATCH` as `[]any`, validates element types and rejects empty strings, then substitutes `*` segments in order via `strings.Replace(name, "*", part, 1)`.
- README "Wildcard Tasks" section is updated with the new array shape and a breaking-change callout.
- Wildcard tests in `execute_test.go` and `tools_test.go` exercise the array shape, including arity validation, non-string elements, and a value containing a comma.

> **Breaking change**: Clients that previously sent `MATCH` as a comma-separated string (e.g. `"api,production"`) must update to send a JSON array (e.g. `["api","production"]`). Worth bundling into the same release as #86 and #87.

Closes #84
