### PR TITLE
feat(exec)!: structured tool result content for stdout/stderr/status

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ executes `task deploy:api:production`.
 
 > **Breaking change**: previous releases accepted `MATCH` as a single comma-separated string (e.g. `"api,production"`). Update clients to send a JSON array of strings instead. Values may now safely contain commas.
 
+## Tool Result Shape
+
+Each task invocation returns a `CallToolResult` with up to three `TextContent` blocks so clients can render or filter streams independently:
+
+1. **Status block** (always present): a one-line summary such as `Task `build` exited with status 0`. Failing tasks surface the underlying exit code reported by `go-task` (e.g. `Task `fail` exited with status 7: ...`); non-exec failures (such as setup errors) fall back to `Task `<name>` failed: <error>`.
+2. **Stdout block** (if non-empty): the captured standard output, with `Meta: {"stream": "stdout"}`.
+3. **Stderr block** (if non-empty): the captured standard error, with `Meta: {"stream": "stderr"}`.
+
+`IsError` is set to `true` whenever the underlying task returns an error, so clients can react to failure without parsing the status line.
+
 ## MCP Integration
 
 This server implements the Model Context Protocol and can be used with any MCP-compatible client or AI assistant. The server:

--- a/internal/taskfileserver/execute.go
+++ b/internal/taskfileserver/execute.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/go-task/task/v3"
+	taskerrors "github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/taskfile/ast"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -113,30 +115,49 @@ func createTaskHandlerForWorkdir(workdir, taskName string) mcp.ToolHandler {
 		// Execute the task
 		taskErr := executor.Run(ctx, call)
 
-		// Collect output
-		stdoutStr := stdout.String()
-		stderrStr := stderr.String()
-
-		// Build result message
-		var result strings.Builder
-
-		if taskErr != nil {
-			fmt.Fprintf(&result, "Task '%s' failed with error: %v\n", resolvedName, taskErr)
-		} else {
-			fmt.Fprintf(&result, "Task '%s' completed successfully.\n", resolvedName)
-		}
-
-		if stdoutStr != "" {
-			result.WriteString("\nOutput:\n" + stdoutStr)
-		}
-
-		if stderrStr != "" {
-			result.WriteString("\nErrors:\n" + stderrStr)
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: result.String()}},
-			IsError: taskErr != nil,
-		}, nil
+		return buildTaskResult(resolvedName, taskErr, stdout.String(), stderr.String()), nil
 	}
+}
+
+// buildTaskResult assembles the structured CallToolResult for a task
+// invocation. The first content block is always a status line; stdout
+// and stderr (when non-empty) are appended as separate TextContent
+// blocks tagged with a "stream" entry in their Meta map so clients can
+// route, filter, or render them independently.
+func buildTaskResult(taskName string, taskErr error, stdoutStr, stderrStr string) *mcp.CallToolResult {
+	content := []mcp.Content{&mcp.TextContent{Text: taskStatusText(taskName, taskErr)}}
+
+	if stdoutStr != "" {
+		content = append(content, &mcp.TextContent{
+			Text: stdoutStr,
+			Meta: mcp.Meta{"stream": "stdout"},
+		})
+	}
+	if stderrStr != "" {
+		content = append(content, &mcp.TextContent{
+			Text: stderrStr,
+			Meta: mcp.Meta{"stream": "stderr"},
+		})
+	}
+
+	return &mcp.CallToolResult{
+		Content: content,
+		IsError: taskErr != nil,
+	}
+}
+
+// taskStatusText returns a one-line status summary for a task invocation.
+// On success the line reports an exit status of 0. On failure it prefers
+// the underlying task exit code from go-task's *TaskRunError, falling
+// back to the raw error message for non-exec failures (e.g. setup errors
+// surfaced by the executor).
+func taskStatusText(taskName string, taskErr error) string {
+	if taskErr == nil {
+		return fmt.Sprintf("Task `%s` exited with status 0", taskName)
+	}
+	var runErr *taskerrors.TaskRunError
+	if errors.As(taskErr, &runErr) {
+		return fmt.Sprintf("Task `%s` exited with status %d: %v", taskName, runErr.TaskExitCode(), taskErr)
+	}
+	return fmt.Sprintf("Task `%s` failed: %v", taskName, taskErr)
 }

--- a/internal/taskfileserver/execute_test.go
+++ b/internal/taskfileserver/execute_test.go
@@ -25,21 +25,21 @@ func TestCreateTaskHandlerForWorkdir_WildcardMATCH(t *testing.T) {
 			taskName:    "start:*",
 			toolName:    "start",
 			arguments:   map[string]any{"MATCH": []string{"web"}},
-			wantSubstrs: []string{"completed successfully", "web"},
+			wantSubstrs: []string{"exited with status 0", "web"},
 		},
 		{
 			name:        "multi wildcard success",
 			taskName:    "deploy:*:*",
 			toolName:    "deploy",
 			arguments:   map[string]any{"MATCH": []string{"api", "production"}},
-			wantSubstrs: []string{"completed successfully", "api", "production"},
+			wantSubstrs: []string{"exited with status 0", "api", "production"},
 		},
 		{
 			name:        "value containing comma is preserved",
 			taskName:    "start:*",
 			toolName:    "start",
 			arguments:   map[string]any{"MATCH": []string{"a,b"}},
-			wantSubstrs: []string{"completed successfully", "a,b"},
+			wantSubstrs: []string{"exited with status 0", "a,b"},
 		},
 		{
 			name:        "missing MATCH",
@@ -131,5 +131,83 @@ func TestCreateTaskHandlerForWorkdir_InvalidArguments(t *testing.T) {
 	text := toolResultText(t, result)
 	if !strings.Contains(text, "Failed to parse") {
 		t.Errorf("expected parse error message, got %q", text)
+	}
+}
+
+func TestCreateTaskHandlerForWorkdir_StructuredSuccessContent(t *testing.T) {
+	s := newTempServer(t, []byte("version: '3'\ntasks:\n  noisy:\n    desc: Emit on both streams\n    cmds:\n      - sh -c 'echo out-line; echo err-line 1>&2'\n"))
+	root := onlyRoot(t, s)
+
+	handler := createTaskHandlerForWorkdir(root.workdir, "noisy")
+	result := callToolHandler(t, handler, "noisy", nil)
+
+	if result.IsError {
+		t.Fatalf("expected success, got IsError=true: %s", toolResultText(t, result))
+	}
+	if got, want := len(result.Content), 3; got != want {
+		t.Fatalf("expected %d content blocks (status, stdout, stderr), got %d", want, got)
+	}
+
+	status := toolStatusText(t, result)
+	if !strings.Contains(status, "Task `noisy` exited with status 0") {
+		t.Errorf("status block %q does not match expected exit-0 line", status)
+	}
+
+	stdout := toolStreamText(t, result, "stdout")
+	if !strings.Contains(stdout, "out-line") {
+		t.Errorf("stdout block %q does not contain expected output", stdout)
+	}
+	if strings.Contains(stdout, "err-line") {
+		t.Errorf("stdout block leaked stderr content: %q", stdout)
+	}
+
+	stderr := toolStreamText(t, result, "stderr")
+	if !strings.Contains(stderr, "err-line") {
+		t.Errorf("stderr block %q does not contain expected error output", stderr)
+	}
+	if strings.Contains(stderr, "out-line") {
+		t.Errorf("stderr block leaked stdout content: %q", stderr)
+	}
+}
+
+func TestCreateTaskHandlerForWorkdir_StructuredFailureContent(t *testing.T) {
+	s := newTempServer(t, []byte("version: '3'\ntasks:\n  fail:\n    desc: Fail with both streams\n    cmds:\n      - sh -c 'echo before-fail; echo bad-news 1>&2; exit 7'\n"))
+	root := onlyRoot(t, s)
+
+	handler := createTaskHandlerForWorkdir(root.workdir, "fail")
+	result := callToolHandler(t, handler, "fail", nil)
+
+	if !result.IsError {
+		t.Fatalf("expected IsError=true for failing task, got success: %s", toolResultText(t, result))
+	}
+
+	status := toolStatusText(t, result)
+	if !strings.Contains(status, "Task `fail` exited with status 7") {
+		t.Errorf("expected status block to surface exit code 7, got %q", status)
+	}
+
+	if stdout := toolStreamText(t, result, "stdout"); !strings.Contains(stdout, "before-fail") {
+		t.Errorf("expected stdout block to contain pre-failure output, got %q", stdout)
+	}
+	if stderr := toolStreamText(t, result, "stderr"); !strings.Contains(stderr, "bad-news") {
+		t.Errorf("expected stderr block to contain failing command stderr, got %q", stderr)
+	}
+}
+
+func TestCreateTaskHandlerForWorkdir_StructuredSilentSuccess(t *testing.T) {
+	s := newTempServer(t, []byte("version: '3'\ntasks:\n  quiet:\n    desc: A task with no output\n    cmds:\n      - 'true'\n"))
+	root := onlyRoot(t, s)
+
+	handler := createTaskHandlerForWorkdir(root.workdir, "quiet")
+	result := callToolHandler(t, handler, "quiet", nil)
+
+	if result.IsError {
+		t.Fatalf("expected success, got IsError=true: %s", toolResultText(t, result))
+	}
+	if got, want := len(result.Content), 1; got != want {
+		t.Fatalf("expected %d content blocks (status only) when streams are empty, got %d", want, got)
+	}
+	if status := toolStatusText(t, result); !strings.Contains(status, "exited with status 0") {
+		t.Errorf("expected status block to report exit 0, got %q", status)
 	}
 }

--- a/internal/taskfileserver/integration_test.go
+++ b/internal/taskfileserver/integration_test.go
@@ -124,9 +124,11 @@ func TestHandleInitialized_CallToolExecutesSingleRootTool(t *testing.T) {
 		t.Fatalf("expected success, got IsError=true: %s", toolResultText(t, result))
 	}
 
-	text := toolResultText(t, result)
-	if !strings.Contains(text, "completed successfully") || !strings.Contains(text, "hello") {
-		t.Fatalf("expected successful hello output, got %q", text)
+	if status := toolStatusText(t, result); !strings.Contains(status, "exited with status 0") {
+		t.Fatalf("expected status block to report exit 0, got %q", status)
+	}
+	if stdout := toolStreamText(t, result, "stdout"); !strings.Contains(stdout, "hello") {
+		t.Fatalf("expected stdout block to contain hello, got %q", stdout)
 	}
 }
 
@@ -516,9 +518,11 @@ func TestHandleRootsChanged_TransitionToUnprefixedCallTool(t *testing.T) {
 		t.Fatalf("expected success, got IsError=true: %s", toolResultText(t, result))
 	}
 
-	text := toolResultText(t, result)
-	if !strings.Contains(text, "completed successfully") || !strings.Contains(text, "two") {
-		t.Fatalf("expected successful task2 output, got %q", text)
+	if status := toolStatusText(t, result); !strings.Contains(status, "exited with status 0") {
+		t.Fatalf("expected status block to report exit 0, got %q", status)
+	}
+	if stdout := toolStreamText(t, result, "stdout"); !strings.Contains(stdout, "two") {
+		t.Fatalf("expected stdout block to contain task2 output, got %q", stdout)
 	}
 
 	ts.mu.Lock()

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -230,18 +231,62 @@ func callToolHandler(t *testing.T, handler mcp.ToolHandler, name string, argumen
 	return result
 }
 
+// toolResultText concatenates the text from every TextContent block in a
+// CallToolResult, separated by newlines. It is used by tests that want to
+// substring-match across the structured status / stdout / stderr blocks
+// without caring which block produced the match.
 func toolResultText(t *testing.T, result *mcp.CallToolResult) string {
 	t.Helper()
 
-	if len(result.Content) != 1 {
-		t.Fatalf("expected exactly 1 content item, got %d", len(result.Content))
+	if len(result.Content) == 0 {
+		t.Fatal("expected at least 1 content item, got 0")
 	}
 
+	parts := make([]string, 0, len(result.Content))
+	for i, c := range result.Content {
+		text, ok := c.(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("expected TextContent at index %d, got %T", i, c)
+		}
+		parts = append(parts, text.Text)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// toolStreamText returns the concatenated text from TextContent blocks
+// tagged with Meta["stream"] == stream (e.g. "stdout", "stderr"). Returns
+// the empty string if no such block exists.
+func toolStreamText(t *testing.T, result *mcp.CallToolResult, stream string) string {
+	t.Helper()
+
+	var parts []string
+	for i, c := range result.Content {
+		text, ok := c.(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("expected TextContent at index %d, got %T", i, c)
+		}
+		if text.Meta == nil {
+			continue
+		}
+		if got, _ := text.Meta["stream"].(string); got == stream {
+			parts = append(parts, text.Text)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// toolStatusText returns the text from the first content block, which by
+// convention carries the status summary line for a task invocation.
+func toolStatusText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+
+	if len(result.Content) == 0 {
+		t.Fatal("expected at least 1 content item, got 0")
+	}
 	text, ok := result.Content[0].(*mcp.TextContent)
 	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
+		t.Fatalf("expected first content to be TextContent, got %T", result.Content[0])
 	}
-
 	return text.Text
 }
 

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -444,9 +444,11 @@ func TestBuildToolPlan_HandlerExecutesSelectedTool(t *testing.T) {
 		t.Fatalf("expected success, got IsError=true: %s", toolResultText(t, result))
 	}
 
-	text := toolResultText(t, result)
-	if !strings.Contains(text, "completed successfully") || !strings.Contains(text, "hello") {
-		t.Fatalf("expected successful greet output, got %q", text)
+	if status := toolStatusText(t, result); !strings.Contains(status, "exited with status 0") {
+		t.Fatalf("expected status block to report exit 0, got %q", status)
+	}
+	if stdout := toolStreamText(t, result, "stdout"); !strings.Contains(stdout, "hello") {
+		t.Fatalf("expected stdout block to contain hello, got %q", stdout)
 	}
 }
 
@@ -484,9 +486,12 @@ func TestBuildToolPlan_HandlerReportsTaskFailure(t *testing.T) {
 		t.Fatal("expected IsError=true for a failing task")
 	}
 
-	text := toolResultText(t, result)
-	if !strings.Contains(text, "failed") {
-		t.Fatalf("expected failure message, got %q", text)
+	status := toolStatusText(t, result)
+	if !strings.Contains(status, "exited with status") {
+		t.Fatalf("expected status block to report exit status, got %q", status)
+	}
+	if strings.Contains(status, "exited with status 0") {
+		t.Fatalf("failing task should not report status 0, got %q", status)
 	}
 }
 


### PR DESCRIPTION
Splits the single text block returned for each task invocation into discrete content items so MCP clients can render or filter stdout, stderr, and the status line independently. The status line now reports the underlying exit code from go-task's `*TaskRunError` rather than a prose "completed successfully" / "failed with error" message. Closes #87.

- Return separate `TextContent` blocks for stdout and stderr, tagged with `Meta["stream"] = "stdout"|"stderr"`
- Add a leading status block of the form ``Task `<name>` exited with status N`` (or ``Task `<name>` failed: <error>`` for non-exec failures), with `IsError` still mirroring the underlying task error
- Update `toolResultText` to concatenate all blocks and add `toolStreamText` / `toolStatusText` helpers for tests
- Migrate existing handler/integration assertions to the new shape and add focused tests covering success-with-both-streams, failing tasks (exit-code surfacing), and silent success
- Document the new tool result shape in the README

**Breaking change**: tool results no longer concatenate stdout, stderr, and a prose status line into a single `TextContent` block. Clients that parsed the old `"completed successfully"` / `"Output:"` / `"Errors:"` format must read the new structured blocks instead.

Closes #87
