### PR TITLE
refactor(taskfileserver): split reconcileRoots into named methods

### DIFF
--- a/internal/taskfileserver/reconcile_test.go
+++ b/internal/taskfileserver/reconcile_test.go
@@ -1,0 +1,206 @@
+package taskfileserver
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// writeTaskfile creates a directory with a Taskfile that defines a single
+// task. It returns the directory's canonical root URI.
+func writeTaskfile(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := []byte("version: '3'\ntasks:\n  " + name + ":\n    desc: " + name + "\n    cmds:\n      - echo " + name + "\n")
+	if err := os.WriteFile(filepath.Join(dir, "Taskfile.yml"), body, 0o600); err != nil {
+		t.Fatalf("write Taskfile: %v", err)
+	}
+	return dirToURI(dir)
+}
+
+// newReconcileServer returns a Server suitable for reconcile tests: it has
+// a registered tool registry but no live watchers.
+func newReconcileServer() *Server {
+	s := New()
+	s.toolRegistry = noopRegistry{}
+	return s
+}
+
+func TestInitializeRoots_AdditiveAndIdempotent(t *testing.T) {
+	uriA := writeTaskfile(t, "alpha")
+	uriB := writeTaskfile(t, "beta")
+
+	s := newReconcileServer()
+
+	res, err := s.initializeRoots(t.Context(), testRoots(uriA))
+	if err != nil {
+		t.Fatalf("initializeRoots first: %v", err)
+	}
+	if !slices.Equal(res.added, []string{uriA}) {
+		t.Fatalf("first added = %v, want [%s]", res.added, uriA)
+	}
+	if len(res.removed) != 0 {
+		t.Fatalf("first removed = %v, want empty", res.removed)
+	}
+
+	// A second initializeRoots that omits uriA must NOT remove it; uriB
+	// is added on top.
+	res, err = s.initializeRoots(t.Context(), testRoots(uriB))
+	if err != nil {
+		t.Fatalf("initializeRoots second: %v", err)
+	}
+	if !slices.Equal(res.added, []string{uriB}) {
+		t.Fatalf("second added = %v, want [%s]", res.added, uriB)
+	}
+	if len(res.removed) != 0 {
+		t.Fatalf("second removed = %v, want empty (initializeRoots is additive)", res.removed)
+	}
+
+	s.mu.Lock()
+	_, hasA := s.roots[uriA]
+	_, hasB := s.roots[uriB]
+	s.mu.Unlock()
+	if !hasA || !hasB {
+		t.Fatalf("expected both roots present, got hasA=%v hasB=%v", hasA, hasB)
+	}
+}
+
+func TestInitializeRoots_RequiresNonEmpty(t *testing.T) {
+	s := newReconcileServer()
+
+	if _, err := s.initializeRoots(t.Context(), nil); err == nil {
+		t.Fatal("expected error from initializeRoots with no roots")
+	}
+
+	// Invalid URIs are skipped; if nothing valid remains the call must error.
+	if _, err := s.initializeRoots(t.Context(), testRoots("not-a-valid-uri")); err == nil {
+		t.Fatal("expected error from initializeRoots when all URIs are invalid")
+	}
+
+	s.mu.Lock()
+	n := len(s.roots)
+	s.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("expected 0 roots after failed init, got %d", n)
+	}
+}
+
+func TestReplaceRoots_RemovesMissingAndAddsNew(t *testing.T) {
+	uriA := writeTaskfile(t, "alpha")
+	uriB := writeTaskfile(t, "beta")
+	uriC := writeTaskfile(t, "gamma")
+
+	s := newReconcileServer()
+
+	if _, err := s.initializeRoots(t.Context(), testRoots(uriA, uriB)); err != nil {
+		t.Fatalf("initializeRoots: %v", err)
+	}
+
+	res := s.replaceRoots(t.Context(), testRoots(uriB, uriC))
+
+	slices.Sort(res.added)
+	slices.Sort(res.removed)
+	if !slices.Equal(res.added, []string{uriC}) {
+		t.Fatalf("added = %v, want [%s]", res.added, uriC)
+	}
+	if !slices.Equal(res.removed, []string{uriA}) {
+		t.Fatalf("removed = %v, want [%s]", res.removed, uriA)
+	}
+
+	s.mu.Lock()
+	_, hasA := s.roots[uriA]
+	_, hasB := s.roots[uriB]
+	_, hasC := s.roots[uriC]
+	s.mu.Unlock()
+	if hasA {
+		t.Errorf("uriA should have been removed")
+	}
+	if !hasB || !hasC {
+		t.Errorf("expected uriB and uriC to be present, got hasB=%v hasC=%v", hasB, hasC)
+	}
+}
+
+func TestReplaceRoots_AllowsEmpty(t *testing.T) {
+	uriA := writeTaskfile(t, "alpha")
+
+	s := newReconcileServer()
+	if _, err := s.initializeRoots(t.Context(), testRoots(uriA)); err != nil {
+		t.Fatalf("initializeRoots: %v", err)
+	}
+
+	res := s.replaceRoots(t.Context(), nil)
+	if !slices.Equal(res.removed, []string{uriA}) {
+		t.Fatalf("removed = %v, want [%s]", res.removed, uriA)
+	}
+	if len(res.added) != 0 {
+		t.Fatalf("added = %v, want empty", res.added)
+	}
+
+	s.mu.Lock()
+	n := len(s.roots)
+	s.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("expected empty root set after replaceRoots(nil), got %d roots", n)
+	}
+}
+
+func TestReplaceRoots_NoChangesYieldsEmptyDiff(t *testing.T) {
+	uriA := writeTaskfile(t, "alpha")
+	uriB := writeTaskfile(t, "beta")
+
+	s := newReconcileServer()
+	if _, err := s.initializeRoots(t.Context(), testRoots(uriA, uriB)); err != nil {
+		t.Fatalf("initializeRoots: %v", err)
+	}
+
+	beforeGen := s.generation
+	res := s.replaceRoots(t.Context(), testRoots(uriA, uriB))
+	if res.changed() {
+		t.Fatalf("expected no diff for identical roots, got added=%v removed=%v", res.added, res.removed)
+	}
+	if s.generation != beforeGen {
+		t.Fatalf("generation should not advance for an unchanged replaceRoots call (before=%d after=%d)", beforeGen, s.generation)
+	}
+}
+
+func TestLoadDesired_SkipsExistingURIs(t *testing.T) {
+	uriA := writeTaskfile(t, "alpha")
+	uriB := writeTaskfile(t, "beta")
+
+	existing := map[string]struct{}{uriA: {}}
+	desired, loaded := loadDesired(t.Context(), testRoots(uriA, uriB), existing)
+
+	if _, ok := desired[uriA]; !ok {
+		t.Fatalf("expected uriA in desired set, got %v", desired)
+	}
+	if _, ok := desired[uriB]; !ok {
+		t.Fatalf("expected uriB in desired set, got %v", desired)
+	}
+	if _, ok := loaded[uriA]; ok {
+		t.Fatalf("loadDesired should not reload an existing root, got %v", loaded)
+	}
+	if _, ok := loaded[uriB]; !ok {
+		t.Fatalf("loadDesired should load uriB, got %v", loaded)
+	}
+}
+
+func TestLoadDesired_DropsInvalidURIs(t *testing.T) {
+	uriA := writeTaskfile(t, "alpha")
+
+	desired, loaded := loadDesired(
+		t.Context(),
+		testRoots(uriA, "not-a-valid-uri", "https://example.com"),
+		nil,
+	)
+
+	if len(desired) != 1 {
+		t.Fatalf("desired = %v, want exactly uriA", desired)
+	}
+	if _, ok := desired[uriA]; !ok {
+		t.Fatalf("desired missing uriA: %v", desired)
+	}
+	if _, ok := loaded[uriA]; !ok {
+		t.Fatalf("loaded missing uriA: %v", loaded)
+	}
+}

--- a/internal/taskfileserver/roots.go
+++ b/internal/taskfileserver/roots.go
@@ -145,7 +145,14 @@ func newUnloadedRoot(dir string) (*Root, error) {
 	}, nil
 }
 
-// unloadRoot removes and cleans up the root with the given canonical URI.
+// unloadRoot removes the root with the given canonical URI from the
+// server's in-memory map. The caller must hold s.mu.
+//
+// This function is intentionally trivial: per the s.mu invariant, anything
+// called under the lock must be non-blocking and lock-free transitively.
+// Heavier per-root cleanup (e.g. cancelling a per-root watcher and waiting
+// for it to drain) MUST be performed by the caller after s.mu has been
+// released, driven by the removed-URI list returned from replaceRoots.
 func (s *Server) unloadRoot(uri string) {
 	delete(s.roots, uri)
 }

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -31,24 +31,36 @@ func isMethodNotFound(err error) bool {
 	return errors.As(err, &wireErr) && wireErr.Code == jsonrpc.CodeMethodNotFound
 }
 
-type rootReconcileOptions struct {
-	removeMissing            bool
-	requireNonEmpty          bool
-	restartWatchersOnSyncErr bool
+// reconcileResult describes the diff produced by initializeRoots and
+// replaceRoots. It is returned to the caller so that side effects driven
+// by root membership changes (tool sync, watcher lifecycle, future
+// per-root managers) can run after s.mu has been released.
+//
+// added and removed contain canonical root URIs; entries are unique within
+// each slice but ordering is unspecified.
+type reconcileResult struct {
+	added   []string
+	removed []string
 }
 
-// reconcileRoots canonicalizes the incoming roots, loads any new ones, and
-// applies the resulting set to the server state.
-func (s *Server) reconcileRoots(ctx context.Context, roots []*mcp.Root, opts rootReconcileOptions) error {
-	s.mu.Lock()
-	existing := make(map[string]struct{}, len(s.roots))
-	for uri := range s.roots {
-		existing[uri] = struct{}{}
-	}
-	s.mu.Unlock()
+// changed reports whether any roots were added or removed.
+func (r reconcileResult) changed() bool {
+	return len(r.added) > 0 || len(r.removed) > 0
+}
 
+// loadDesired canonicalises raw root specs and loads any roots that are not
+// already present in existing. It does no I/O for URIs already known to the
+// caller. Returns the canonical URI set the caller should converge to and
+// the freshly-loaded roots keyed by canonical URI. Invalid URIs and load
+// failures that cannot fall back to an unloaded placeholder are logged and
+// skipped.
+//
+// This helper performs disk I/O (loadRoot, newUnloadedRoot) and MUST be
+// called without s.mu held.
+func loadDesired(ctx context.Context, roots []*mcp.Root, existing map[string]struct{}) (map[string]struct{}, map[string]*Root) {
 	desiredURIs := make(map[string]struct{}, len(roots))
 	loadedRoots := make(map[string]*Root, len(roots))
+
 	for _, r := range roots {
 		canonicalURI, dir, parseErr := canonicalRootURI(r.URI)
 		if parseErr != nil {
@@ -62,6 +74,7 @@ func (s *Server) reconcileRoots(ctx context.Context, roots []*mcp.Root, opts roo
 		if _, exists := loadedRoots[canonicalURI]; exists {
 			continue
 		}
+
 		root, loadErr := loadRoot(ctx, dir)
 		if loadErr != nil {
 			log.Printf("failed to load root %q: %v", r.URI, loadErr)
@@ -74,60 +87,129 @@ func (s *Server) reconcileRoots(ctx context.Context, roots []*mcp.Root, opts roo
 		loadedRoots[canonicalURI] = root
 	}
 
+	return desiredURIs, loadedRoots
+}
+
+// snapshotExistingRoots returns the set of canonical URIs currently
+// tracked by the server. The returned map is owned by the caller.
+func (s *Server) snapshotExistingRoots() map[string]struct{} {
 	s.mu.Lock()
-	mutated := false
-	if opts.removeMissing {
-		for uri := range s.roots {
-			if _, ok := desiredURIs[uri]; !ok {
-				s.unloadRoot(uri)
-				mutated = true
-			}
-		}
+	defer s.mu.Unlock()
+
+	existing := make(map[string]struct{}, len(s.roots))
+	for uri := range s.roots {
+		existing[uri] = struct{}{}
 	}
+	return existing
+}
+
+// initializeRoots installs the initial set of roots from the client. It is
+// additive: roots already present are left in place and roots not in the
+// desired list are NOT removed. It is an error for the resulting root set
+// to be empty.
+//
+// Side effects (syncTools, restartWatchers, future per-root watcher
+// notifications) are NOT performed here; the caller drives them using the
+// returned reconcileResult after s.mu has been released.
+func (s *Server) initializeRoots(ctx context.Context, roots []*mcp.Root) (reconcileResult, error) {
+	existing := s.snapshotExistingRoots()
+	_, loadedRoots := loadDesired(ctx, roots, existing)
+
+	var res reconcileResult
+	s.mu.Lock()
 	for uri, root := range loadedRoots {
-		if _, exists := s.roots[uri]; exists {
+		if _, present := s.roots[uri]; present {
 			continue
 		}
 		s.roots[uri] = root
-		mutated = true
+		res.added = append(res.added, uri)
 	}
-	if mutated {
+	if res.changed() {
 		s.generation++
 	}
-	if opts.requireNonEmpty && len(s.roots) == 0 {
+	if len(s.roots) == 0 {
 		s.mu.Unlock()
-		return errors.New("no valid roots found")
+		return reconcileResult{}, errors.New("no valid roots found")
 	}
 	s.mu.Unlock()
 
+	return res, nil
+}
+
+// replaceRoots reconciles s.roots so that its membership matches roots
+// exactly: previously loaded roots not in the desired list are removed and
+// new roots are loaded and added. An empty roots list is allowed and
+// results in an empty server root set.
+//
+// Side effects (syncTools, restartWatchers, future per-root watcher
+// notifications) are NOT performed here; the caller drives them using the
+// returned reconcileResult after s.mu has been released.
+func (s *Server) replaceRoots(ctx context.Context, roots []*mcp.Root) reconcileResult {
+	existing := s.snapshotExistingRoots()
+	desiredURIs, loadedRoots := loadDesired(ctx, roots, existing)
+
+	var res reconcileResult
+	s.mu.Lock()
+	for uri := range s.roots {
+		if _, ok := desiredURIs[uri]; ok {
+			continue
+		}
+		s.unloadRoot(uri)
+		res.removed = append(res.removed, uri)
+	}
+	for uri, root := range loadedRoots {
+		if _, present := s.roots[uri]; present {
+			continue
+		}
+		s.roots[uri] = root
+		res.added = append(res.added, uri)
+	}
+	if res.changed() {
+		s.generation++
+	}
+	s.mu.Unlock()
+
+	return res
+}
+
+// initializeRootsFromSession queries the client for its root list and loads
+// each one. If the client does not support roots, it falls back to os.Getwd().
+// On success it drives the post-reconcile side effects (syncTools, watcher
+// start) outside of s.mu.
+func (s *Server) initializeRootsFromSession(ctx context.Context, session *mcp.ServerSession) error {
+	roots, err := listClientRoots(ctx, session)
+	if err != nil {
+		return err
+	}
+
+	if _, err := s.initializeRoots(ctx, roots); err != nil {
+		return err
+	}
+
 	syncErr := s.syncTools()
-	if syncErr == nil || opts.restartWatchersOnSyncErr {
+	if syncErr == nil {
 		s.restartWatchers(ctx)
 	}
 	return syncErr
 }
 
-// initializeRootsFromSession queries the client for its root list and loads
-// each one. If the client does not support roots, it falls back to os.Getwd().
-func (s *Server) initializeRootsFromSession(ctx context.Context, session *mcp.ServerSession) error {
+// listClientRoots returns the desired roots for initialization, falling
+// back to the working directory if the client does not advertise the
+// roots capability.
+func listClientRoots(ctx context.Context, session *mcp.ServerSession) ([]*mcp.Root, error) {
 	rootRes, err := session.ListRoots(ctx, nil)
-	if err != nil {
-		if !isMethodNotFound(err) {
-			return fmt.Errorf("failed to list roots: %w", err)
-		}
-		// Client does not support roots; fall back to working directory.
-		workdir, wdErr := os.Getwd()
-		if wdErr != nil {
-			return fmt.Errorf("failed to get working directory: %w", wdErr)
-		}
-		return s.reconcileRoots(ctx, []*mcp.Root{{URI: dirToURI(workdir)}}, rootReconcileOptions{
-			requireNonEmpty: true,
-		})
+	if err == nil {
+		return rootRes.Roots, nil
+	}
+	if !isMethodNotFound(err) {
+		return nil, fmt.Errorf("failed to list roots: %w", err)
 	}
 
-	return s.reconcileRoots(ctx, rootRes.Roots, rootReconcileOptions{
-		requireNonEmpty: true,
-	})
+	workdir, wdErr := os.Getwd()
+	if wdErr != nil {
+		return nil, fmt.Errorf("failed to get working directory: %w", wdErr)
+	}
+	return []*mcp.Root{{URI: dirToURI(workdir)}}, nil
 }
 
 // HandleInitialized is called after the client handshake completes.
@@ -138,6 +220,8 @@ func (s *Server) HandleInitialized(ctx context.Context, req *mcp.InitializedRequ
 }
 
 // HandleRootsChanged is called when the client sends roots/list_changed.
+// It always restarts the file watchers (regardless of whether syncTools
+// succeeds) so the watcher set continues to track the live root membership.
 func (s *Server) HandleRootsChanged(ctx context.Context, req *mcp.RootsListChangedRequest) {
 	rootRes, err := req.Session.ListRoots(ctx, nil)
 	if err != nil {
@@ -145,10 +229,10 @@ func (s *Server) HandleRootsChanged(ctx context.Context, req *mcp.RootsListChang
 		return
 	}
 
-	if err := s.reconcileRoots(ctx, rootRes.Roots, rootReconcileOptions{
-		removeMissing:            true,
-		restartWatchersOnSyncErr: true,
-	}); err != nil {
+	_ = s.replaceRoots(ctx, rootRes.Roots)
+
+	if err := s.syncTools(); err != nil {
 		log.Printf("failed to sync tools after roots change: %v", err)
 	}
+	s.restartWatchers(ctx)
 }

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -27,6 +27,14 @@ type toolRegistry interface {
 }
 
 // Server represents our MCP server for Taskfile.yml.
+//
+// The mu mutex protects in-memory mutations of roots, registeredTools,
+// generation, and the watcher bookkeeping fields (watchCancel, watchDone,
+// shuttingDown). Functions called while holding mu must not block,
+// perform I/O, or interact with goroutines that themselves acquire mu.
+// Heavier lifecycle work (loading Taskfiles, cancelling watchers,
+// notifying the MCP registry) MUST be driven by callers after mu has
+// been released.
 type Server struct {
 	roots           map[string]*Root
 	toolRegistry    toolRegistry

--- a/internal/taskfileserver/watch_test.go
+++ b/internal/taskfileserver/watch_test.go
@@ -583,9 +583,13 @@ func TestReconcileRoots_MissingInitialTaskfileLoadsWhenCreatedLater(t *testing.T
 	s.toolRegistry = noopRegistry{}
 	defer s.Shutdown()
 
-	if err := s.reconcileRoots(t.Context(), testRoots(uri), rootReconcileOptions{requireNonEmpty: true}); err != nil {
-		t.Fatalf("reconcileRoots: %v", err)
+	if _, err := s.initializeRoots(t.Context(), testRoots(uri)); err != nil {
+		t.Fatalf("initializeRoots: %v", err)
 	}
+	if err := s.syncTools(); err != nil {
+		t.Fatalf("syncTools: %v", err)
+	}
+	s.restartWatchers(t.Context())
 
 	root := onlyRoot(t, s)
 	if root.taskfile != nil {


### PR DESCRIPTION
Replaces the unified `reconcileRoots(ctx, roots, opts)` and its `rootReconcileOptions` flag soup with two named methods that match the actual call sites, and reshapes the locking story so future per-root cleanup (e.g. the watcher manager planned in #82) can plug in without risking deadlocks against goroutines that re-enter `s.mu`.

- Replace `reconcileRoots` with `initializeRoots` (additive, requires non-empty) and `replaceRoots` (full reconciliation, removes missing).
- Extract a shared `loadDesired` helper that handles canonicalisation and per-root loading outside the lock.
- Return a `reconcileResult{added, removed}` diff so callers drive `syncTools` and `restartWatchers` after `s.mu` is released, providing the clean add/remove seam #82 needs.
- Document the `s.mu` invariant on `Server` and reaffirm it on `unloadRoot`: anything called under the lock must remain non-blocking and lock-free transitively.
- Add tests covering the divergent semantics (additive init, init requires non-empty, replace removes + adds, replace allows empty, no-change replace yields empty diff, `loadDesired` skips existing and drops invalid URIs).

Closes #89