### PR TITLE
feat(watch): per-root watcher manager instead of restart-all

### DIFF
--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -13,10 +13,12 @@ import (
 
 // New creates a new Taskfile MCP server.
 func New() *Server {
-	return &Server{
+	s := &Server{
 		roots:           make(map[string]*Root),
 		registeredTools: make(map[string]registeredTool),
 	}
+	s.watchers = newWatcherManager(s.runRootWatcher)
+	return s
 }
 
 // SetToolRegistry attaches the registry used for tool registration updates.
@@ -108,9 +110,9 @@ func (s *Server) snapshotExistingRoots() map[string]struct{} {
 // desired list are NOT removed. It is an error for the resulting root set
 // to be empty.
 //
-// Side effects (syncTools, restartWatchers, future per-root watcher
-// notifications) are NOT performed here; the caller drives them using the
-// returned reconcileResult after s.mu has been released.
+// Side effects (syncTools, watcher start/stop) are NOT performed here;
+// the caller drives them using the returned reconcileResult after s.mu
+// has been released.
 func (s *Server) initializeRoots(ctx context.Context, roots []*mcp.Root) (reconcileResult, error) {
 	existing := s.snapshotExistingRoots()
 	_, loadedRoots := loadDesired(ctx, roots, existing)
@@ -141,9 +143,9 @@ func (s *Server) initializeRoots(ctx context.Context, roots []*mcp.Root) (reconc
 // new roots are loaded and added. An empty roots list is allowed and
 // results in an empty server root set.
 //
-// Side effects (syncTools, restartWatchers, future per-root watcher
-// notifications) are NOT performed here; the caller drives them using the
-// returned reconcileResult after s.mu has been released.
+// Side effects (syncTools, watcher start/stop) are NOT performed here;
+// the caller drives them using the returned reconcileResult after s.mu
+// has been released.
 func (s *Server) replaceRoots(ctx context.Context, roots []*mcp.Root) reconcileResult {
 	existing := s.snapshotExistingRoots()
 	desiredURIs, loadedRoots := loadDesired(ctx, roots, existing)
@@ -182,13 +184,14 @@ func (s *Server) initializeRootsFromSession(ctx context.Context, session *mcp.Se
 		return err
 	}
 
-	if _, err := s.initializeRoots(ctx, roots); err != nil {
+	res, err := s.initializeRoots(ctx, roots)
+	if err != nil {
 		return err
 	}
 
 	syncErr := s.syncTools()
 	if syncErr == nil {
-		s.restartWatchers(ctx)
+		s.watchers.apply(ctx, res.added, res.removed)
 	}
 	return syncErr
 }
@@ -220,8 +223,9 @@ func (s *Server) HandleInitialized(ctx context.Context, req *mcp.InitializedRequ
 }
 
 // HandleRootsChanged is called when the client sends roots/list_changed.
-// It always restarts the file watchers (regardless of whether syncTools
-// succeeds) so the watcher set continues to track the live root membership.
+// It applies the per-root watcher diff regardless of whether syncTools
+// succeeds, so the watcher set continues to track the live root
+// membership.
 func (s *Server) HandleRootsChanged(ctx context.Context, req *mcp.RootsListChangedRequest) {
 	rootRes, err := req.Session.ListRoots(ctx, nil)
 	if err != nil {
@@ -229,10 +233,10 @@ func (s *Server) HandleRootsChanged(ctx context.Context, req *mcp.RootsListChang
 		return
 	}
 
-	_ = s.replaceRoots(ctx, rootRes.Roots)
+	res := s.replaceRoots(ctx, rootRes.Roots)
 
 	if err := s.syncTools(); err != nil {
 		log.Printf("failed to sync tools after roots change: %v", err)
 	}
-	s.restartWatchers(ctx)
+	s.watchers.apply(ctx, res.added, res.removed)
 }

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -1,7 +1,6 @@
 package taskfileserver
 
 import (
-	"context"
 	"sync"
 
 	"github.com/go-task/task/v3/taskfile/ast"
@@ -12,7 +11,8 @@ import (
 // into Server.roots its fields are treated as read-only; mutations are
 // performed by replacing the pointer in the map rather than writing
 // through the existing value, so concurrent readers (snapshots, watchers)
-// always observe a consistent state.
+// always observe a consistent state. *Root values therefore must NOT be
+// mutated outside roots.go.
 type Root struct {
 	taskfile       *ast.Taskfile
 	workdir        string
@@ -29,21 +29,22 @@ type toolRegistry interface {
 // Server represents our MCP server for Taskfile.yml.
 //
 // The mu mutex protects in-memory mutations of roots, registeredTools,
-// generation, and the watcher bookkeeping fields (watchCancel, watchDone,
-// shuttingDown). Functions called while holding mu must not block,
+// and generation. Functions called while holding mu must not block,
 // perform I/O, or interact with goroutines that themselves acquire mu.
 // Heavier lifecycle work (loading Taskfiles, cancelling watchers,
 // notifying the MCP registry) MUST be driven by callers after mu has
 // been released.
+//
+// The watcher set is owned by watchers, which has its own internal lock
+// and lifecycle that is independent of mu. Callers must not hold mu
+// while invoking watcher methods.
 type Server struct {
 	roots           map[string]*Root
 	toolRegistry    toolRegistry
 	registeredTools map[string]registeredTool
+	watchers        *watcherManager
 	mu              sync.Mutex
 	generation      uint64
-	watchCancel     context.CancelFunc
-	watchDone       chan struct{}
-	shuttingDown    bool
 }
 
 // toolRootSnapshot is an immutable per-root view captured under lock so

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -1,6 +1,7 @@
 package taskfileserver
 
 import (
+	"context"
 	"encoding/json"
 	"maps"
 	"os"
@@ -29,9 +30,9 @@ func loadServerFromFixture(t *testing.T, name string) *Server {
 	}
 
 	uri := dirToURI(dir)
-	return &Server{
-		roots: map[string]*Root{uri: root},
-	}
+	s := New()
+	s.roots[uri] = root
+	return s
 }
 
 // onlyRoot returns the single Root from a server, or fails the test.
@@ -64,7 +65,6 @@ func newTestServer(t *testing.T, fixture string) *Server {
 	s := loadServerFromFixture(t, fixture)
 	mcpSrv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
 	s.toolRegistry = mcpSrv
-	s.registeredTools = make(map[string]registeredTool)
 	return s
 }
 
@@ -127,13 +127,25 @@ func snapshotFromServer(s *Server) toolStateSnapshot {
 	return snap
 }
 
-// snapshotRoots returns a slice of root URIs for use with watchTaskfiles.
+// snapshotRoots returns a slice of canonical root URIs.
 func snapshotRoots(s *Server) []string {
 	uris := make([]string, 0, len(s.roots))
 	for uri := range s.roots {
 		uris = append(uris, uri)
 	}
 	return uris
+}
+
+// startTestWatchers spawns a per-root watcher goroutine for every loaded
+// root. It mimics what the watcherManager does on a normal startup, but
+// without going through the manager so tests can observe the raw
+// watchRootTaskfiles loop.
+func startTestWatchers(ctx context.Context, s *Server) {
+	for _, uri := range snapshotRoots(s) {
+		go func(uri string) {
+			_ = s.watchRootTaskfiles(ctx, uri)
+		}(uri)
+	}
 }
 
 // newTempServer creates a Server backed by a temp directory containing
@@ -157,11 +169,9 @@ func newServerForDir(t *testing.T, dir string) *Server {
 	}
 	uri := dirToURI(dir)
 	mcpSrv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
-	s := &Server{
-		roots:           map[string]*Root{uri: root},
-		toolRegistry:    mcpSrv,
-		registeredTools: make(map[string]registeredTool),
-	}
+	s := New()
+	s.toolRegistry = mcpSrv
+	s.roots[uri] = root
 	if err := s.syncTools(); err != nil {
 		t.Fatalf("initial syncTools: %v", err)
 	}

--- a/internal/taskfileserver/watch.go
+++ b/internal/taskfileserver/watch.go
@@ -13,6 +13,161 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+// rootWatcher tracks a single per-root watcher goroutine.
+type rootWatcher struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// watcherManager owns the lifecycle of per-root watcher goroutines. Each
+// root URI is watched by at most one goroutine; the manager spawns
+// watchers for newly added URIs and cancels watchers for removed URIs
+// without disturbing the rest. The manager has its own internal lock and
+// must be invoked without Server.mu held.
+type watcherManager struct {
+	// run executes the per-root watch loop. It receives a context that
+	// is cancelled when the watcher is stopped (via apply, reconcile, or
+	// shutdown). The function MUST return promptly after ctx is
+	// cancelled so shutdown can drain.
+	run func(ctx context.Context, uri string)
+
+	mu           sync.Mutex
+	watchers     map[string]*rootWatcher
+	shuttingDown bool
+}
+
+// newWatcherManager constructs an empty manager. run is the per-root
+// watch loop the manager will spawn for each URI.
+func newWatcherManager(run func(ctx context.Context, uri string)) *watcherManager {
+	return &watcherManager{
+		run:      run,
+		watchers: make(map[string]*rootWatcher),
+	}
+}
+
+// apply spawns watchers for URIs in added that are not already running
+// and cancels watchers for URIs in removed. The cancelled watchers exit
+// asynchronously; apply does not wait for them. baseCtx is detached via
+// context.WithoutCancel so watchers outlive the caller's request scope.
+//
+// apply is a no-op once shutdown has been called.
+func (m *watcherManager) apply(baseCtx context.Context, added, removed []string) {
+	type spawn struct {
+		uri string
+		ctx context.Context
+		w   *rootWatcher
+	}
+
+	var (
+		stopping []*rootWatcher
+		spawning []spawn
+	)
+
+	m.mu.Lock()
+	if m.shuttingDown {
+		m.mu.Unlock()
+		return
+	}
+	for _, uri := range removed {
+		if w, ok := m.watchers[uri]; ok {
+			stopping = append(stopping, w)
+			delete(m.watchers, uri)
+		}
+	}
+	parent := context.WithoutCancel(baseCtx)
+	for _, uri := range added {
+		if _, ok := m.watchers[uri]; ok {
+			continue
+		}
+		// cancel is stored in rootWatcher.cancel and invoked from
+		// apply (on removal) or shutdown; gosec cannot trace this.
+		ctx, cancel := context.WithCancel(parent) //nolint:gosec // cancel is held in rootWatcher.cancel
+		w := &rootWatcher{cancel: cancel, done: make(chan struct{})}
+		m.watchers[uri] = w
+		spawning = append(spawning, spawn{uri: uri, ctx: ctx, w: w})
+	}
+	m.mu.Unlock()
+
+	for _, w := range stopping {
+		w.cancel()
+	}
+	for _, sp := range spawning {
+		go func() {
+			defer close(sp.w.done)
+			m.run(sp.ctx, sp.uri)
+		}()
+	}
+}
+
+// reconcile diffs the running watchers against desired and applies the
+// difference. Existing watchers for URIs in desired are not disturbed.
+// reconcile is a no-op once shutdown has been called.
+func (m *watcherManager) reconcile(baseCtx context.Context, desired []string) {
+	desiredSet := make(map[string]struct{}, len(desired))
+	for _, uri := range desired {
+		desiredSet[uri] = struct{}{}
+	}
+
+	var added, removed []string
+
+	m.mu.Lock()
+	if m.shuttingDown {
+		m.mu.Unlock()
+		return
+	}
+	for uri := range m.watchers {
+		if _, ok := desiredSet[uri]; !ok {
+			removed = append(removed, uri)
+		}
+	}
+	for uri := range desiredSet {
+		if _, ok := m.watchers[uri]; !ok {
+			added = append(added, uri)
+		}
+	}
+	m.mu.Unlock()
+
+	m.apply(baseCtx, added, removed)
+}
+
+// shutdown cancels every running watcher and waits for them to exit.
+// After shutdown returns, all subsequent apply and reconcile calls are
+// no-ops. shutdown is idempotent and safe to call from multiple
+// goroutines concurrently.
+func (m *watcherManager) shutdown() {
+	m.mu.Lock()
+	if m.shuttingDown {
+		m.mu.Unlock()
+		return
+	}
+	m.shuttingDown = true
+	watchers := m.watchers
+	m.watchers = make(map[string]*rootWatcher)
+	m.mu.Unlock()
+
+	for _, w := range watchers {
+		w.cancel()
+	}
+	for _, w := range watchers {
+		<-w.done
+	}
+}
+
+// active reports the number of running watchers. Intended for tests.
+func (m *watcherManager) active() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.watchers)
+}
+
+// isShuttingDown reports whether shutdown has been called. Intended for
+// tests.
+func (m *watcherManager) isShuttingDown() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.shuttingDown
+}
+
 // rootWatchState returns copies of the current watch configuration for a root.
 func (s *Server) rootWatchState(uri string) ([]string, map[string]struct{}, bool) {
 	s.mu.Lock()
@@ -131,90 +286,38 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 	}
 }
 
-// watchTaskfiles starts file watchers for the given root URIs and blocks until
-// the context is cancelled. The caller must provide URIs captured under lock.
-func (s *Server) watchTaskfiles(ctx context.Context, rootURIs []string) error {
-	var wg sync.WaitGroup
-	var firstErr error
-	var errOnce sync.Once
-
-	for _, uri := range rootURIs {
-		wg.Go(func() {
-			if err := s.watchRootTaskfiles(ctx, uri); err != nil {
-				errOnce.Do(func() { firstErr = err })
-			}
-		})
+// runRootWatcher is the watcherManager run callback. It logs and discards
+// any error returned by watchRootTaskfiles so a failed watcher does not
+// take down the manager's bookkeeping.
+func (s *Server) runRootWatcher(ctx context.Context, uri string) {
+	if err := s.watchRootTaskfiles(ctx, uri); err != nil {
+		log.Printf("file watcher for %s failed: %v", uri, err)
 	}
-
-	wg.Wait()
-	return firstErr
 }
 
-// Shutdown stops any detached watcher goroutines and waits for them to exit.
-// It is safe to call multiple times.
+// Shutdown stops every running watcher and waits for them to exit. It is
+// idempotent and safe to call multiple times. After Shutdown returns,
+// future calls into the watcher manager become no-ops.
 func (s *Server) Shutdown() {
-	s.mu.Lock()
-	if s.shuttingDown {
-		s.mu.Unlock()
-		return
-	}
-
-	s.shuttingDown = true
-	cancel := s.watchCancel
-	done := s.watchDone
-	s.watchCancel = nil
-	s.watchDone = nil
-	s.mu.Unlock()
-
-	if cancel != nil {
-		cancel()
-	}
-	if done != nil {
-		<-done
-	}
+	s.watchers.shutdown()
 }
 
-// restartWatchers cancels any running file watchers, waits for them to exit,
-// then starts new ones for all current roots. The provided ctx is
-// intentionally detached via context.WithoutCancel because callers pass
-// request-scoped contexts that are cancelled after the handler returns.
+// restartWatchers reconciles the watcher set so that one watcher is
+// running per current root. It is a thin wrapper around the per-root
+// watcher manager: existing watchers are left running, watchers for
+// removed roots are cancelled, and watchers for newly added roots are
+// spawned.
+//
+// The provided ctx is detached via context.WithoutCancel inside the
+// manager, because callers may pass request-scoped contexts that are
+// cancelled after the handler returns; watchers must outlive the request.
 func (s *Server) restartWatchers(ctx context.Context) {
 	s.mu.Lock()
-	if s.shuttingDown {
-		s.mu.Unlock()
-		return
-	}
-
-	// Capture previous watcher generation's cancel and done channel.
-	prevCancel := s.watchCancel
-	prevDone := s.watchDone
-
-	// Snapshot root URIs while we hold the lock.
 	rootURIs := make([]string, 0, len(s.roots))
 	for uri := range s.roots {
 		rootURIs = append(rootURIs, uri)
 	}
-
-	// Prepare the new watcher generation before releasing the lock.
-	// Detach from the caller's request-scoped context which is cancelled
-	// after the handler returns; the watcher must outlive the request.
-	watchCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	done := make(chan struct{})
-	s.watchCancel = cancel
-	s.watchDone = done
 	s.mu.Unlock()
 
-	if prevCancel != nil {
-		prevCancel()
-	}
-	if prevDone != nil {
-		<-prevDone
-	}
-
-	go func() {
-		defer close(done)
-		if err := s.watchTaskfiles(watchCtx, rootURIs); err != nil {
-			log.Printf("file watcher failed: %v", err)
-		}
-	}()
+	s.watchers.reconcile(ctx, rootURIs)
 }

--- a/internal/taskfileserver/watch_test.go
+++ b/internal/taskfileserver/watch_test.go
@@ -60,9 +60,7 @@ func TestWatchTaskfiles_ReloadsOnChange(t *testing.T) {
 
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	// Give the watcher time to start.
 	time.Sleep(100 * time.Millisecond)
@@ -116,9 +114,7 @@ func TestWatchTaskfiles_IgnoresUnincludedChildTaskfile(t *testing.T) {
 	initialTaskfile := root.taskfile
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -152,9 +148,7 @@ func TestWatchTaskfiles_ReloadsOnIncludedTaskfileChange(t *testing.T) {
 	s := newServerForDir(t, dir)
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -204,9 +198,7 @@ func TestWatchTaskfiles_ReloadsOnTransitiveIncludedTaskfileChange(t *testing.T) 
 	s := newServerForDir(t, dir)
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -247,9 +239,7 @@ func TestWatchTaskfiles_IgnoresNonTaskfile(t *testing.T) {
 
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -270,19 +260,20 @@ func TestWatchTaskfiles_IgnoresNonTaskfile(t *testing.T) {
 	}
 }
 
-func TestWatchTaskfiles_CancelStops(t *testing.T) {
+func TestWatchRootTaskfiles_CancelStops(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "Taskfile.yml"), []byte("version: '3'\ntasks:\n  x:\n    cmds:\n      - echo x\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	s := newServerForDir(t, dir)
+	uri := onlyRootURI(t, s)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 
 	go func() {
-		done <- s.watchTaskfiles(ctx, snapshotRoots(s))
+		done <- s.watchRootTaskfiles(ctx, uri)
 	}()
 
 	time.Sleep(50 * time.Millisecond)
@@ -291,10 +282,10 @@ func TestWatchTaskfiles_CancelStops(t *testing.T) {
 	select {
 	case err := <-done:
 		if err != nil {
-			t.Errorf("watchTaskfiles returned error: %v", err)
+			t.Errorf("watchRootTaskfiles returned error: %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("watchTaskfiles did not stop after context cancellation")
+		t.Fatal("watchRootTaskfiles did not stop after context cancellation")
 	}
 }
 
@@ -307,31 +298,26 @@ func TestServerShutdown_StopsActiveWatchersAndIsIdempotent(t *testing.T) {
 	s := newServerForDir(t, dir)
 	s.restartWatchers(context.Background())
 
-	s.mu.Lock()
-	watchDone := s.watchDone
-	s.mu.Unlock()
-	if watchDone == nil {
-		t.Fatal("expected active watcher generation")
+	if got := s.watchers.active(); got == 0 {
+		t.Fatalf("expected at least one active watcher, got %d", got)
 	}
 
-	s.Shutdown()
-
+	shutdownDone := make(chan struct{})
+	go func() {
+		s.Shutdown()
+		close(shutdownDone)
+	}()
 	select {
-	case <-watchDone:
+	case <-shutdownDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("Shutdown did not wait for watcher generation to stop")
+		t.Fatal("Shutdown did not return in time")
 	}
 
-	s.mu.Lock()
-	watchCancel := s.watchCancel
-	remainingDone := s.watchDone
-	shuttingDown := s.shuttingDown
-	s.mu.Unlock()
-	if watchCancel != nil || remainingDone != nil {
-		t.Fatal("expected watcher state to be cleared after Shutdown")
+	if got := s.watchers.active(); got != 0 {
+		t.Fatalf("expected 0 active watchers after Shutdown, got %d", got)
 	}
-	if !shuttingDown {
-		t.Fatal("expected server to reject watcher restarts after Shutdown")
+	if !s.watchers.isShuttingDown() {
+		t.Fatal("expected watcher manager to remain in shutting-down state after Shutdown")
 	}
 
 	done := make(chan struct{})
@@ -339,7 +325,6 @@ func TestServerShutdown_StopsActiveWatchersAndIsIdempotent(t *testing.T) {
 		s.Shutdown()
 		close(done)
 	}()
-
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
@@ -348,10 +333,8 @@ func TestServerShutdown_StopsActiveWatchersAndIsIdempotent(t *testing.T) {
 
 	s.restartWatchers(context.Background())
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.watchCancel != nil || s.watchDone != nil {
-		t.Fatal("restartWatchers should be a no-op after Shutdown")
+	if got := s.watchers.active(); got != 0 {
+		t.Fatalf("restartWatchers should be a no-op after Shutdown, got %d active watchers", got)
 	}
 }
 
@@ -447,9 +430,7 @@ func TestWatchTaskfiles_DebounceCoalesces(t *testing.T) {
 	// appears without intermediate states lingering.
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -489,9 +470,7 @@ func TestWatchTaskfiles_InvalidRootTaskfileRemovesToolsUntilRestored(t *testing.
 
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -536,9 +515,7 @@ func TestWatchTaskfiles_DeletedRootTaskfileRemovesToolsUntilRestored(t *testing.
 
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -658,9 +635,7 @@ func TestWatchTaskfiles_NewSubdirectory(t *testing.T) {
 
 	ctx := t.Context()
 
-	go func() {
-		_ = s.watchTaskfiles(ctx, snapshotRoots(s))
-	}()
+	startTestWatchers(ctx, s)
 
 	time.Sleep(100 * time.Millisecond)
 

--- a/internal/taskfileserver/watcher_manager_test.go
+++ b/internal/taskfileserver/watcher_manager_test.go
@@ -1,0 +1,254 @@
+package taskfileserver
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeWatcherFn records how many times each URI's watch loop has been
+// started, blocks until ctx is cancelled, and exits cleanly.
+type fakeWatcherFn struct {
+	mu     sync.Mutex
+	starts map[string]int
+	live   map[string]chan struct{}
+}
+
+func newFakeWatcherFn() *fakeWatcherFn {
+	return &fakeWatcherFn{
+		starts: make(map[string]int),
+		live:   make(map[string]chan struct{}),
+	}
+}
+
+func (f *fakeWatcherFn) run(ctx context.Context, uri string) {
+	f.mu.Lock()
+	f.starts[uri]++
+	exited := make(chan struct{})
+	f.live[uri] = exited
+	f.mu.Unlock()
+	defer close(exited)
+	<-ctx.Done()
+}
+
+func (f *fakeWatcherFn) startsFor(uri string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.starts[uri]
+}
+
+func (f *fakeWatcherFn) liveChan(uri string) chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.live[uri]
+}
+
+// waitForActive polls m.active() until it equals want or the deadline
+// expires.
+func waitForActive(t *testing.T, m *watcherManager, want int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if got := m.active(); got == want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d active watchers, have %d", want, m.active())
+		case <-tick.C:
+		}
+	}
+}
+
+// waitForStart polls until fake.startsFor(uri) is at least 1, i.e. the
+// watcher goroutine has entered its run loop after apply spawned it.
+func waitForStart(t *testing.T, fake *fakeWatcherFn, uri string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if fake.startsFor(uri) >= 1 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for watcher %q to start, starts=%d", uri, fake.startsFor(uri))
+		case <-tick.C:
+		}
+	}
+}
+
+func TestWatcherManager_ApplyAddsAndRemoves(t *testing.T) {
+	fake := newFakeWatcherFn()
+	m := newWatcherManager(fake.run)
+	t.Cleanup(m.shutdown)
+
+	ctx := t.Context()
+
+	m.apply(ctx, []string{"a", "b"}, nil)
+	waitForActive(t, m, 2)
+	waitForStart(t, fake, "a")
+	waitForStart(t, fake, "b")
+
+	// Capture the live channels so we can verify the EXISTING watchers
+	// keep running across a subsequent apply (no mass restart).
+	liveA := fake.liveChan("a")
+	liveB := fake.liveChan("b")
+
+	m.apply(ctx, []string{"c"}, []string{"a"})
+	waitForStart(t, fake, "c")
+
+	// "a" should have been cancelled; "b" must NOT be disturbed.
+	select {
+	case <-liveA:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher for 'a' did not exit after cancellation")
+	}
+
+	select {
+	case <-liveB:
+		t.Fatal("watcher for 'b' was unexpectedly cancelled by an unrelated apply")
+	case <-time.After(50 * time.Millisecond):
+		// expected: b is still running
+	}
+
+	waitForActive(t, m, 2)
+	if fake.startsFor("b") != 1 {
+		t.Fatalf("watcher for 'b' should not have been restarted, starts=%d", fake.startsFor("b"))
+	}
+	if fake.startsFor("c") != 1 {
+		t.Fatalf("watcher for 'c' should have been started exactly once, starts=%d", fake.startsFor("c"))
+	}
+}
+
+func TestWatcherManager_ApplyIsIdempotentForExistingURIs(t *testing.T) {
+	fake := newFakeWatcherFn()
+	m := newWatcherManager(fake.run)
+	t.Cleanup(m.shutdown)
+
+	ctx := t.Context()
+
+	m.apply(ctx, []string{"a"}, nil)
+	waitForActive(t, m, 1)
+	waitForStart(t, fake, "a")
+
+	// Re-applying with the same URI in "added" must not start a second
+	// watcher.
+	m.apply(ctx, []string{"a"}, nil)
+	time.Sleep(50 * time.Millisecond)
+
+	if got := fake.startsFor("a"); got != 1 {
+		t.Fatalf("expected exactly one start for 'a', got %d", got)
+	}
+	if got := m.active(); got != 1 {
+		t.Fatalf("expected 1 active watcher, got %d", got)
+	}
+}
+
+func TestWatcherManager_ShutdownStopsAllAndIsIdempotent(t *testing.T) {
+	fake := newFakeWatcherFn()
+	m := newWatcherManager(fake.run)
+
+	ctx := t.Context()
+	m.apply(ctx, []string{"a", "b", "c"}, nil)
+	waitForActive(t, m, 3)
+	waitForStart(t, fake, "a")
+	waitForStart(t, fake, "b")
+	waitForStart(t, fake, "c")
+
+	done := make(chan struct{})
+	go func() {
+		m.shutdown()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown did not return in time")
+	}
+
+	if got := m.active(); got != 0 {
+		t.Fatalf("expected 0 active watchers after shutdown, got %d", got)
+	}
+
+	// A second shutdown call must not block.
+	done2 := make(chan struct{})
+	go func() {
+		m.shutdown()
+		close(done2)
+	}()
+	select {
+	case <-done2:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second shutdown blocked")
+	}
+
+	// apply and reconcile must be no-ops after shutdown.
+	m.apply(ctx, []string{"d"}, nil)
+	m.reconcile(ctx, []string{"e"})
+	time.Sleep(50 * time.Millisecond)
+	if got := m.active(); got != 0 {
+		t.Fatalf("apply/reconcile should be no-ops after shutdown, got %d active", got)
+	}
+}
+
+func TestWatcherManager_ReconcileDiffsDesiredSet(t *testing.T) {
+	fake := newFakeWatcherFn()
+	m := newWatcherManager(fake.run)
+	t.Cleanup(m.shutdown)
+
+	ctx := t.Context()
+	m.reconcile(ctx, []string{"a", "b"})
+	waitForActive(t, m, 2)
+	waitForStart(t, fake, "a")
+	waitForStart(t, fake, "b")
+
+	liveA := fake.liveChan("a")
+
+	m.reconcile(ctx, []string{"a", "c"})
+	waitForActive(t, m, 2)
+	waitForStart(t, fake, "c")
+
+	// "a" must still be running (untouched); "b" must have been
+	// cancelled; "c" must have been started.
+	select {
+	case <-liveA:
+		t.Fatal("reconcile cancelled watcher for 'a' even though it is in the desired set")
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+	if fake.startsFor("a") != 1 {
+		t.Fatalf("watcher for 'a' should not have been restarted, starts=%d", fake.startsFor("a"))
+	}
+	if fake.startsFor("c") != 1 {
+		t.Fatalf("watcher for 'c' should have been started, starts=%d", fake.startsFor("c"))
+	}
+}
+
+func TestWatcherManager_DetachesFromRequestContext(t *testing.T) {
+	fake := newFakeWatcherFn()
+	m := newWatcherManager(fake.run)
+	t.Cleanup(m.shutdown)
+
+	// Cancel the request-scoped context immediately. The watcher's
+	// own context must be detached and continue to run.
+	reqCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	m.apply(reqCtx, []string{"a"}, nil)
+	waitForActive(t, m, 1)
+	waitForStart(t, fake, "a")
+
+	live := fake.liveChan("a")
+	select {
+	case <-live:
+		t.Fatal("watcher exited because it observed the cancelled request context")
+	case <-time.After(50 * time.Millisecond):
+		// expected: watcher is still running
+	}
+}


### PR DESCRIPTION
Replaces the previous "cancel everything and respawn one goroutine per root" supervisor with a `watcherManager` that owns a stable `map[uri]*rootWatcher`. Adding or removing a single root now spawns or cancels exactly that root's watcher; the other watchers keep running across the reconcile, eliminating the O(n) churn and the brittle pre-bind cancel-before-releasing-the-lock dance around `s.watchCancel`/`s.watchDone`.

- Add `watcherManager` with `apply`, `reconcile`, and `shutdown`. Each per-root goroutine has its own `cancel`/`done`; the manager has its own internal lock that is independent of `s.mu`.
- Use the `reconcileResult` already produced by `initializeRoots`/`replaceRoots` (#89) to drive `apply(added, removed)` directly from `HandleInitialized` and `HandleRootsChanged`.
- Detach watcher contexts via `context.WithoutCancel` inside the manager so they outlive the request-scoped contexts handlers receive.
- Make `Server.Shutdown` delegate to `watcherManager.shutdown`; it is still idempotent and safe to call concurrently. After shutdown, `apply`/`reconcile` become no-ops.
- Shrink `restartWatchers` to a thin wrapper that calls `watcherManager.reconcile` with the current root URIs, kept for tests that exercise the per-root watcher loop directly.
- Drop the now-unused `watchTaskfiles` multi-root supervisor and the `watchCancel`/`watchDone`/`shuttingDown` fields on `Server`.
- Update `state.go` to document `*Root` as effectively read-only outside `roots.go` (carried over from #90).
- Add focused `watcherManager` unit tests covering add/remove without disturbing untouched watchers, idempotent re-adds, request-context detachment, reconcile diffing, and shutdown idempotence.

Closes #82
