### PR TITLE
chore(taskfileserver): replace stdlib log with structured slog

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ The server resolves each root's Taskfile graph using `go-task`, then watches the
 After each reload, the server recomputes the graph-derived watch set so newly included local Taskfiles start being watched and removed ones stop being watched. File system events are debounced (~200 ms) to avoid redundant reloads during rapid edits. The watcher runs for the lifetime of the server and is cleaned up on shutdown.
 If a root Taskfile becomes invalid or is deleted, the server withdraws that root's tools until a valid Taskfile is restored.
 
+## Logging
+
+The server emits structured JSON logs to **stderr** using [`log/slog`](https://pkg.go.dev/log/slog). With the stdio MCP transport, stderr is the only safe channel for diagnostics; stdout is reserved for JSON-RPC traffic.
+
+Each line is a single JSON object with at least:
+
+- `time`, `level`, `msg`
+- `service` and `version` of this server
+- An `event` field naming the specific occurrence (e.g. `root.load_failed`, `tools.collision`, `watcher.reload_failed`)
+- Contextual fields where applicable: `root_uri`, `tool_name`, `error`
+
+The default level is `info`. Set the `MCP_TASKFILE_LOG_LEVEL` environment variable to one of `debug`, `info`, `warn`, or `error` to change it (case-insensitive). Unrecognised values fall back to `info`.
+
+```bash
+MCP_TASKFILE_LOG_LEVEL=debug mcp-taskfile-server
+```
+
+> Mirroring selected log lines to the connected MCP client via the [`logging` capability](https://modelcontextprotocol.io/specification/2025-11-25/server/logging) is tracked in [#98](https://github.com/rsclarke/mcp-taskfile-server/issues/98); today the server only logs to stderr.
+
 ## Error Handling
 
 The server handles various error conditions:

--- a/internal/taskfileserver/logging_test.go
+++ b/internal/taskfileserver/logging_test.go
@@ -1,0 +1,59 @@
+package taskfileserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestSetLogger_StructuredFields verifies the server's slog.Logger is
+// honoured and emits the expected structured fields for a known event.
+func TestSetLogger_StructuredFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	s := New()
+	s.SetLogger(logger)
+
+	// Invoke loadDesired with a syntactically invalid URI so it logs the
+	// "root.invalid_uri" event without performing any disk I/O.
+	s.loadDesired(t.Context(), testRoots("not-a-valid-uri"), nil)
+
+	if buf.Len() == 0 {
+		t.Fatal("expected at least one log line, got none")
+	}
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	var entry map[string]any
+	for _, line := range lines {
+		var got map[string]any
+		if err := json.Unmarshal([]byte(line), &got); err != nil {
+			t.Fatalf("invalid JSON log line %q: %v", line, err)
+		}
+		if got["event"] == "root.invalid_uri" {
+			entry = got
+			break
+		}
+	}
+	if entry == nil {
+		t.Fatalf("did not find root.invalid_uri event in logs: %s", buf.String())
+	}
+	if entry["root_uri"] != "not-a-valid-uri" {
+		t.Errorf("root_uri = %v, want %q", entry["root_uri"], "not-a-valid-uri")
+	}
+	if entry["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", entry["level"])
+	}
+}
+
+// TestSetLogger_NilRestoresDiscard ensures passing a nil logger does
+// not panic and silences subsequent calls.
+func TestSetLogger_NilRestoresDiscard(t *testing.T) {
+	s := New()
+	s.SetLogger(nil)
+
+	// Should not panic.
+	s.loadDesired(t.Context(), testRoots("not-a-valid-uri"), nil)
+}

--- a/internal/taskfileserver/reconcile_test.go
+++ b/internal/taskfileserver/reconcile_test.go
@@ -169,7 +169,8 @@ func TestLoadDesired_SkipsExistingURIs(t *testing.T) {
 	uriB := writeTaskfile(t, "beta")
 
 	existing := map[string]struct{}{uriA: {}}
-	desired, loaded := loadDesired(t.Context(), testRoots(uriA, uriB), existing)
+	s := New()
+	desired, loaded := s.loadDesired(t.Context(), testRoots(uriA, uriB), existing)
 
 	if _, ok := desired[uriA]; !ok {
 		t.Fatalf("expected uriA in desired set, got %v", desired)
@@ -188,7 +189,8 @@ func TestLoadDesired_SkipsExistingURIs(t *testing.T) {
 func TestLoadDesired_DropsInvalidURIs(t *testing.T) {
 	uriA := writeTaskfile(t, "alpha")
 
-	desired, loaded := loadDesired(
+	s := New()
+	desired, loaded := s.loadDesired(
 		t.Context(),
 		testRoots(uriA, "not-a-valid-uri", "https://example.com"),
 		nil,

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// New creates a new Taskfile MCP server.
+// New creates a new Taskfile MCP server. The server starts with a
+// silent logger; callers should override it via SetLogger before Run.
 func New() *Server {
 	s := &Server{
 		roots:           make(map[string]*Root),
 		registeredTools: make(map[string]registeredTool),
+		logger:          slog.New(slog.DiscardHandler),
 	}
 	s.watchers = newWatcherManager(s.runRootWatcher)
 	return s
@@ -24,6 +26,16 @@ func New() *Server {
 // SetToolRegistry attaches the registry used for tool registration updates.
 func (s *Server) SetToolRegistry(registry toolRegistry) {
 	s.toolRegistry = registry
+}
+
+// SetLogger replaces the structured logger used by the server. Passing
+// a nil logger restores the default silent logger so Server methods can
+// log unconditionally without nil-checking.
+func (s *Server) SetLogger(logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	s.logger = logger
 }
 
 // isMethodNotFound reports whether err is a JSON-RPC "method not found" error,
@@ -59,14 +71,18 @@ func (r reconcileResult) changed() bool {
 //
 // This helper performs disk I/O (loadRoot, newUnloadedRoot) and MUST be
 // called without s.mu held.
-func loadDesired(ctx context.Context, roots []*mcp.Root, existing map[string]struct{}) (map[string]struct{}, map[string]*Root) {
+func (s *Server) loadDesired(ctx context.Context, roots []*mcp.Root, existing map[string]struct{}) (map[string]struct{}, map[string]*Root) {
 	desiredURIs := make(map[string]struct{}, len(roots))
 	loadedRoots := make(map[string]*Root, len(roots))
 
 	for _, r := range roots {
 		canonicalURI, dir, parseErr := canonicalRootURI(r.URI)
 		if parseErr != nil {
-			log.Printf("skipping root with invalid URI %q: %v", r.URI, parseErr)
+			s.logger.Warn("skipping root with invalid URI",
+				slog.String("event", "root.invalid_uri"),
+				slog.String("root_uri", r.URI),
+				slog.Any("error", parseErr),
+			)
 			continue
 		}
 		desiredURIs[canonicalURI] = struct{}{}
@@ -79,10 +95,18 @@ func loadDesired(ctx context.Context, roots []*mcp.Root, existing map[string]str
 
 		root, loadErr := loadRoot(ctx, dir)
 		if loadErr != nil {
-			log.Printf("failed to load root %q: %v", r.URI, loadErr)
+			s.logger.Warn("failed to load root, falling back to unloaded placeholder",
+				slog.String("event", "root.load_failed"),
+				slog.String("root_uri", r.URI),
+				slog.Any("error", loadErr),
+			)
 			root, loadErr = newUnloadedRoot(dir)
 			if loadErr != nil {
-				log.Printf("failed to watch unloaded root %q: %v", r.URI, loadErr)
+				s.logger.Error("failed to watch unloaded root",
+					slog.String("event", "root.unloaded_failed"),
+					slog.String("root_uri", r.URI),
+					slog.Any("error", loadErr),
+				)
 				continue
 			}
 		}
@@ -115,7 +139,7 @@ func (s *Server) snapshotExistingRoots() map[string]struct{} {
 // has been released.
 func (s *Server) initializeRoots(ctx context.Context, roots []*mcp.Root) (reconcileResult, error) {
 	existing := s.snapshotExistingRoots()
-	_, loadedRoots := loadDesired(ctx, roots, existing)
+	_, loadedRoots := s.loadDesired(ctx, roots, existing)
 
 	var res reconcileResult
 	s.mu.Lock()
@@ -148,7 +172,7 @@ func (s *Server) initializeRoots(ctx context.Context, roots []*mcp.Root) (reconc
 // has been released.
 func (s *Server) replaceRoots(ctx context.Context, roots []*mcp.Root) reconcileResult {
 	existing := s.snapshotExistingRoots()
-	desiredURIs, loadedRoots := loadDesired(ctx, roots, existing)
+	desiredURIs, loadedRoots := s.loadDesired(ctx, roots, existing)
 
 	var res reconcileResult
 	s.mu.Lock()
@@ -218,7 +242,10 @@ func listClientRoots(ctx context.Context, session *mcp.ServerSession) ([]*mcp.Ro
 // HandleInitialized is called after the client handshake completes.
 func (s *Server) HandleInitialized(ctx context.Context, req *mcp.InitializedRequest) {
 	if err := s.initializeRootsFromSession(ctx, req.Session); err != nil {
-		log.Printf("failed to initialize roots: %v", err)
+		s.logger.Error("failed to initialize roots",
+			slog.String("event", "roots.init_failed"),
+			slog.Any("error", err),
+		)
 	}
 }
 
@@ -229,14 +256,20 @@ func (s *Server) HandleInitialized(ctx context.Context, req *mcp.InitializedRequ
 func (s *Server) HandleRootsChanged(ctx context.Context, req *mcp.RootsListChangedRequest) {
 	rootRes, err := req.Session.ListRoots(ctx, nil)
 	if err != nil {
-		log.Printf("failed to list roots after change: %v", err)
+		s.logger.Error("failed to list roots after change",
+			slog.String("event", "roots.list_failed"),
+			slog.Any("error", err),
+		)
 		return
 	}
 
 	res := s.replaceRoots(ctx, rootRes.Roots)
 
 	if err := s.syncTools(); err != nil {
-		log.Printf("failed to sync tools after roots change: %v", err)
+		s.logger.Error("failed to sync tools after roots change",
+			slog.String("event", "tools.sync_failed"),
+			slog.Any("error", err),
+		)
 	}
 	s.watchers.apply(ctx, res.added, res.removed)
 }

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -1,6 +1,7 @@
 package taskfileserver
 
 import (
+	"log/slog"
 	"sync"
 
 	"github.com/go-task/task/v3/taskfile/ast"
@@ -43,6 +44,7 @@ type Server struct {
 	toolRegistry    toolRegistry
 	registeredTools map[string]registeredTool
 	watchers        *watcherManager
+	logger          *slog.Logger
 	mu              sync.Mutex
 	generation      uint64
 }

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -3,6 +3,7 @@ package taskfileserver
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -16,6 +17,13 @@ import (
 	"github.com/go-task/task/v3/taskfile/ast"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// testLogger returns a logger that discards all output. Tests that need
+// to assert on log output should construct their own buffer-backed
+// handler instead.
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
 
 // loadServerFromFixture creates a Server from a testdata fixture directory.
 func loadServerFromFixture(t *testing.T, name string) *Server {

--- a/internal/taskfileserver/tools.go
+++ b/internal/taskfileserver/tools.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"maps"
 	"slices"
 	"strings"
@@ -130,8 +130,10 @@ type toolPlan struct {
 }
 
 // buildToolPlan computes the desired tool registration state from a snapshot
-// without accessing or mutating the server.
-func buildToolPlan(snap toolStateSnapshot) toolPlan {
+// without accessing or mutating the server. logger receives diagnostics
+// for plan-level decisions such as colliding tool names; passing a nil
+// logger panics.
+func buildToolPlan(snap toolStateSnapshot, logger *slog.Logger) toolPlan {
 	type toolCandidate struct {
 		workdir  string
 		taskName string
@@ -181,7 +183,11 @@ func buildToolPlan(snap toolStateSnapshot) toolPlan {
 				details = append(details, fmt.Sprintf("%s (%s)", candidate.taskName, candidate.workdir))
 			}
 			slices.Sort(details)
-			log.Printf("excluding colliding tool name %q from MCP exposure: %s", name, strings.Join(details, ", "))
+			logger.Warn("excluding colliding tool name from MCP exposure",
+				slog.String("event", "tools.collision"),
+				slog.String("tool_name", name),
+				slog.String("candidates", strings.Join(details, ", ")),
+			)
 			continue
 		}
 
@@ -235,7 +241,7 @@ func (s *Server) syncTools() error {
 	s.mu.Unlock()
 
 	// Phase 2: pure planning — no lock held.
-	plan := buildToolPlan(snap)
+	plan := buildToolPlan(snap, s.logger)
 	stale, added := diffTools(oldTools, plan.tools)
 
 	// Phase 3: validate generation, apply MCP side effects, and commit

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -202,7 +202,7 @@ func TestCreateToolForTask_RequiresEnum(t *testing.T) {
 func TestBuildToolPlan_SkipsInternal(t *testing.T) {
 	s := loadServerFromFixture(t, "internal")
 
-	tools := buildToolPlan(snapshotFromServer(s)).tools
+	tools := buildToolPlan(snapshotFromServer(s), testLogger()).tools
 
 	if len(tools) != 1 {
 		t.Fatalf("expected 1 tool, got %d", len(tools))
@@ -397,7 +397,7 @@ func TestCreateToolForTask_LeadingDot(t *testing.T) {
 func TestBuildToolPlan_Namespaced(t *testing.T) {
 	s := loadServerFromFixture(t, "namespaced")
 
-	tools := buildToolPlan(snapshotFromServer(s)).tools
+	tools := buildToolPlan(snapshotFromServer(s), testLogger()).tools
 
 	for _, want := range []string{"db_migrate", "uv_run", "uv_run_dev_lint-imports"} {
 		if _, ok := tools[want]; !ok {
@@ -409,7 +409,7 @@ func TestBuildToolPlan_Namespaced(t *testing.T) {
 func TestBuildToolPlan_Includes(t *testing.T) {
 	s := loadServerFromFixture(t, "includes")
 
-	tools := buildToolPlan(snapshotFromServer(s)).tools
+	tools := buildToolPlan(snapshotFromServer(s), testLogger()).tools
 
 	for _, want := range []string{"build", "docs_serve", "docs_build"} {
 		if _, ok := tools[want]; !ok {
@@ -421,7 +421,7 @@ func TestBuildToolPlan_Includes(t *testing.T) {
 func TestBuildToolPlan_Wildcard(t *testing.T) {
 	s := loadServerFromFixture(t, "wildcard")
 
-	tools := buildToolPlan(snapshotFromServer(s)).tools
+	tools := buildToolPlan(snapshotFromServer(s), testLogger()).tools
 
 	for _, want := range []string{"start", "deploy"} {
 		if _, ok := tools[want]; !ok {
@@ -433,7 +433,7 @@ func TestBuildToolPlan_Wildcard(t *testing.T) {
 func TestBuildToolPlan_HandlerExecutesSelectedTool(t *testing.T) {
 	s := loadServerFromFixture(t, "basic")
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	handler, ok := plan.handlers["greet"]
 	if !ok {
 		t.Fatalf("missing handler for greet, got %v", toolNames(plan.tools))
@@ -455,7 +455,7 @@ func TestBuildToolPlan_HandlerExecutesSelectedTool(t *testing.T) {
 func TestBuildToolPlan_HandlerPassesVariables(t *testing.T) {
 	s := newTempServer(t, []byte("version: '3'\ntasks:\n  greet:\n    desc: Greet someone\n    cmds:\n      - echo hello {{.NAME}}\n"))
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	handler, ok := plan.handlers["greet"]
 	if !ok {
 		t.Fatalf("missing handler for greet, got %v", toolNames(plan.tools))
@@ -475,7 +475,7 @@ func TestBuildToolPlan_HandlerPassesVariables(t *testing.T) {
 func TestBuildToolPlan_HandlerReportsTaskFailure(t *testing.T) {
 	s := newTempServer(t, []byte("version: '3'\ntasks:\n  fail:\n    desc: A failing task\n    cmds:\n      - exit 1\n"))
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	handler, ok := plan.handlers["fail"]
 	if !ok {
 		t.Fatalf("missing handler for fail, got %v", toolNames(plan.tools))
@@ -498,7 +498,7 @@ func TestBuildToolPlan_HandlerReportsTaskFailure(t *testing.T) {
 func TestBuildToolPlan_HandlerExecutesWildcardTool(t *testing.T) {
 	s := loadServerFromFixture(t, "wildcard")
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	handler, ok := plan.handlers["deploy"]
 	if !ok {
 		t.Fatalf("missing handler for deploy, got %v", toolNames(plan.tools))
@@ -551,7 +551,7 @@ func TestBuildToolPlan_HandlerSelectsPrefixedRootTool(t *testing.T) {
 		},
 	}
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	frontendHandler, ok := plan.handlers["frontend_serve"]
 	if !ok {
 		t.Fatalf("missing frontend handler, got %v", toolNames(plan.tools))
@@ -696,7 +696,7 @@ func TestBuildToolPlan_ExcludesCollidingToolNamesAcrossRoots(t *testing.T) {
 		},
 	}
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	tools, handlers := plan.tools, plan.handlers
 
 	if _, ok := tools["dup_hello"]; ok {
@@ -728,7 +728,7 @@ func TestBuildToolPlan_ExcludesCollidingToolNamesWithinRoot(t *testing.T) {
 		roots: map[string]*Root{dirToURI(dir): root},
 	}
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	tools, handlers := plan.tools, plan.handlers
 	if _, ok := tools["build_dev"]; ok {
 		t.Fatalf("expected colliding tool build_dev to be excluded, got %v", toolNames(tools))
@@ -756,7 +756,7 @@ func TestBuildToolPlan_NoTasks(t *testing.T) {
 		roots: map[string]*Root{dirToURI(dir): root},
 	}
 
-	plan := buildToolPlan(snapshotFromServer(s))
+	plan := buildToolPlan(snapshotFromServer(s), testLogger())
 	tools, handlers := plan.tools, plan.handlers
 	if len(tools) != 0 {
 		t.Fatalf("expected no tools, got %v", toolNames(tools))
@@ -863,7 +863,7 @@ func TestBuildToolPlan_FromSnapshot(t *testing.T) {
 		},
 	}
 
-	plan := buildToolPlan(snap)
+	plan := buildToolPlan(snap, testLogger())
 	if _, ok := plan.tools["greet"]; !ok {
 		t.Fatalf("expected tool greet, got %v", toolNames(plan.tools))
 	}
@@ -986,7 +986,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 	s.mu.Unlock()
 
 	// G1 plans from the stale snapshot (both tasks).
-	plan := buildToolPlan(snap)
+	plan := buildToolPlan(snap, testLogger())
 	stale, added := diffTools(oldTools, plan.tools)
 
 	// G1 tries to apply — generation should mismatch, no MCP calls.
@@ -1057,7 +1057,7 @@ func TestSnapshotToolState_IsolatedFromRootMutation(t *testing.T) {
 	// Planner must run safely against the snapshot, observing the
 	// taskfile that was current at snapshot time, not the now-nil
 	// field on the live root.
-	plan := buildToolPlan(snap)
+	plan := buildToolPlan(snap, testLogger())
 	if _, ok := plan.tools["greet"]; !ok {
 		t.Fatalf("expected snapshotted plan to retain greet, got %v", toolNames(plan.tools))
 	}

--- a/internal/taskfileserver/watch.go
+++ b/internal/taskfileserver/watch.go
@@ -3,7 +3,7 @@ package taskfileserver
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"maps"
 	"path/filepath"
 	"slices"
@@ -246,7 +246,11 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 		case <-timer.C:
 			timerPending = false
 			if err := s.reloadRoot(ctx, uri); err != nil {
-				log.Printf("failed to reload tools for root %s: %v", uri, err)
+				s.logger.Error("failed to reload tools for root",
+					slog.String("event", "watcher.reload_failed"),
+					slog.String("root_uri", uri),
+					slog.Any("error", err),
+				)
 				continue
 			}
 
@@ -281,7 +285,11 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 			if !ok {
 				return nil
 			}
-			log.Printf("file watcher error: %v", err)
+			s.logger.Warn("file watcher error",
+				slog.String("event", "watcher.fs_error"),
+				slog.String("root_uri", uri),
+				slog.Any("error", err),
+			)
 		}
 	}
 }
@@ -291,7 +299,11 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 // take down the manager's bookkeeping.
 func (s *Server) runRootWatcher(ctx context.Context, uri string) {
 	if err := s.watchRootTaskfiles(ctx, uri); err != nil {
-		log.Printf("file watcher for %s failed: %v", uri, err)
+		s.logger.Error("file watcher failed",
+			slog.String("event", "watcher.failed"),
+			slog.String("root_uri", uri),
+			slog.Any("error", err),
+		)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rsclarke/mcp-taskfile-server/internal/taskfileserver"
@@ -16,9 +18,43 @@ var (
 	serverVersion = "dev"
 )
 
+// logLevelEnv names the environment variable used to configure the log
+// level. Recognised values: debug, info, warn, error (case-insensitive).
+const logLevelEnv = "MCP_TASKFILE_LOG_LEVEL"
+
+// parseLogLevel resolves the configured log level. Unrecognised or empty
+// values fall back to info.
+func parseLogLevel(raw string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// newLogger builds the structured logger used by the server. It writes
+// JSON to stderr (the only safe channel under stdio MCP transport) and
+// honours MCP_TASKFILE_LOG_LEVEL.
+func newLogger() *slog.Logger {
+	level := parseLogLevel(os.Getenv(logLevelEnv))
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	return slog.New(handler).With(
+		slog.String("service", serverName),
+		slog.String("version", serverVersion),
+	)
+}
+
 func run() error {
+	logger := newLogger()
+
 	// Create taskfile server
 	taskfileServer := taskfileserver.New()
+	taskfileServer.SetLogger(logger)
 	defer taskfileServer.Shutdown()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -37,7 +73,11 @@ func run() error {
 	)
 	taskfileServer.SetToolRegistry(mcpServer)
 
-	// Start the stdio server
+	// Start the stdio server.
+	//
+	// TODO(#98): mirror selected log lines through the MCP `logging`
+	// capability so they reach the client. Tracked separately from #88
+	// (slog migration) and the deferral in commit 84473b2 (#87).
 	if err := mcpServer.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		return fmt.Errorf("server error: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want slog.Level
+	}{
+		{"", slog.LevelInfo},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"  info  ", slog.LevelInfo},
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"bogus", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			if got := parseLogLevel(tc.raw); got != tc.want {
+				t.Errorf("parseLogLevel(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Routes every diagnostic through a per-Server `*slog.Logger` so log output is filterable, correlatable JSON on stderr instead of unstructured prose. Closes #88 and lays groundwork for the deferred MCP `logging`-capability mirror tracked in #98 (originally pushed back in commit 84473b2 / #87).

- Replace every `log.Printf` call site across server.go, tools.go, and watch.go with `slog` calls carrying a stable `event` attribute plus contextual fields (`root_uri`, `tool_name`, `error`, ...).
- Add a `logger` field on `Server` plus `SetLogger`; `New()` defaults to `slog.DiscardHandler` so tests stay silent and can inject a buffer-backed handler when they need to assert on output.
- Convert `loadDesired` to a method on `Server` and pass an explicit `*slog.Logger` into `buildToolPlan` so package-level helpers can log without globals.
- Configure log level via the `MCP_TASKFILE_LOG_LEVEL` env var (`debug`/`info`/`warn`/`error`, case-insensitive; default `info`; unrecognised values fall back to `info`).
- Wire the production logger in `main.go` (JSON handler on stderr, enriched with `service` and `version`) and leave a `TODO(#98)` so the deferred MCP-logging mirror lands cleanly later.
- Add `TestSetLogger_StructuredFields` (buffer-backed DI smoke test), `TestSetLogger_NilRestoresDiscard`, and `TestParseLogLevel` covering the env-var defaults.
- Document the new logging shape and env var in README.md and link the deferred work to #98.

Closes #88
Refs #87
Refs #98