### PR TITLE
feat(logging): mirror server logs through MCP logging capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,16 @@ The default level is `info`. Set the `MCP_TASKFILE_LOG_LEVEL` environment variab
 MCP_TASKFILE_LOG_LEVEL=debug mcp-taskfile-server
 ```
 
-> Mirroring selected log lines to the connected MCP client via the [`logging` capability](https://modelcontextprotocol.io/specification/2025-11-25/server/logging) is tracked in [#98](https://github.com/rsclarke/mcp-taskfile-server/issues/98); today the server only logs to stderr.
+### MCP Logging Capability
+
+In addition to writing to stderr, the server advertises the MCP [`logging` capability](https://modelcontextprotocol.io/specification/2025-11-25/server/logging) and mirrors every record through the active session as a `notifications/message` notification using the Go SDK's [`mcp.LoggingHandler`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#LoggingHandler). The two sinks are independent:
+
+- **Stderr** is the source of truth and is gated by `MCP_TASKFILE_LOG_LEVEL`.
+- **MCP forwarding** is gated by the client-set threshold via `logging/setLevel`. Until the client raises the level, the SDK suppresses every record, so connecting clients see no log noise unless they opt in.
+
+The structured attributes (`event`, `root_uri`, `tool_name`, `error`, etc.) are forwarded verbatim as the notification's `data` payload so clients can filter on them. The MCP arm is wired in only after the client handshake completes; records emitted earlier reach stderr alone.
+
+> **Note:** the server is built around a single MCP session per process — `Server.Run` over stdio binds exactly one — so the in-band logging stream is always unambiguously scoped to "this client". Multi-tenant HTTP deployments are out of scope today; if added, the recommended pattern is one `*mcp.Server` per session via [`NewStreamableHTTPHandler`'s `getServer` factory](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#NewStreamableHTTPHandler), which preserves this 1:1 invariant.
 
 ## Error Handling
 

--- a/internal/taskfileserver/logging.go
+++ b/internal/taskfileserver/logging.go
@@ -1,0 +1,64 @@
+package taskfileserver
+
+import (
+	"context"
+	"log/slog"
+)
+
+// fanoutHandler dispatches every record to multiple slog.Handlers,
+// allowing the server to emit a single log line to both the stderr JSON
+// sink and the SDK's MCP LoggingHandler without coupling their
+// lifecycles. Per-handler errors are dropped so a failure in one branch
+// does not suppress the others.
+//
+// slog has no built-in multi-handler; this is the minimum needed.
+type fanoutHandler struct {
+	handlers []slog.Handler
+}
+
+// newFanoutHandler returns a handler that forwards every record to each
+// of handlers in order.
+func newFanoutHandler(handlers ...slog.Handler) *fanoutHandler {
+	return &fanoutHandler{handlers: handlers}
+}
+
+// Enabled reports whether any underlying handler is enabled at level.
+func (f *fanoutHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, h := range f.handlers {
+		if h.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle dispatches r to each underlying handler that is enabled.
+// Each handler receives a clone of the record because slog.Record's
+// attributes are encoded lazily.
+func (f *fanoutHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, h := range f.handlers {
+		if !h.Enabled(ctx, r.Level) {
+			continue
+		}
+		_ = h.Handle(ctx, r.Clone())
+	}
+	return nil
+}
+
+// WithAttrs implements slog.Handler.
+func (f *fanoutHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	cloned := make([]slog.Handler, len(f.handlers))
+	for i, h := range f.handlers {
+		cloned[i] = h.WithAttrs(attrs)
+	}
+	return &fanoutHandler{handlers: cloned}
+}
+
+// WithGroup implements slog.Handler.
+func (f *fanoutHandler) WithGroup(name string) slog.Handler {
+	cloned := make([]slog.Handler, len(f.handlers))
+	for i, h := range f.handlers {
+		cloned[i] = h.WithGroup(name)
+	}
+	return &fanoutHandler{handlers: cloned}
+}

--- a/internal/taskfileserver/logging_mcp_test.go
+++ b/internal/taskfileserver/logging_mcp_test.go
@@ -1,0 +1,313 @@
+package taskfileserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestServer_NoMCPLoggingBeforeInitialized verifies that a freshly
+// constructed Server emits records only to its initially configured sink
+// (stderr, here a buffer) and does not panic when no session has been
+// installed.
+func TestServer_NoMCPLoggingBeforeInitialized(t *testing.T) {
+	var buf bytes.Buffer
+	stderr := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	s := New()
+	s.SetLogger(slog.New(stderr))
+
+	s.log().Warn("hello",
+		slog.String("event", "test.before_init"),
+	)
+
+	if buf.Len() == 0 {
+		t.Fatal("expected stderr handler to receive the record")
+	}
+	if !strings.Contains(buf.String(), `"event":"test.before_init"`) {
+		t.Errorf("expected event in stderr buffer, got %s", buf.String())
+	}
+}
+
+// captureLoggingClient wires up an in-memory client/server pair, lets
+// the server's HandleInitialized fire so installMCPLogging runs, and
+// returns a client session along with a channel that receives every
+// logging/message notification the client is sent.
+func captureLoggingClient(t *testing.T, ts *Server) (*mcp.ClientSession, chan *mcp.LoggingMessageParams) {
+	t.Helper()
+
+	notes := make(chan *mcp.LoggingMessageParams, 32)
+
+	client := mcp.NewClient(
+		&mcp.Implementation{Name: "test-client", Version: "0.0.0"},
+		&mcp.ClientOptions{
+			LoggingMessageHandler: func(_ context.Context, req *mcp.LoggingMessageRequest) {
+				select {
+				case notes <- req.Params:
+				default:
+				}
+			},
+		},
+	)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, &mcp.ServerOptions{
+		InitializedHandler:      ts.HandleInitialized,
+		RootsListChangedHandler: ts.HandleRootsChanged,
+	})
+	ts.SetToolRegistry(server)
+
+	ctx := t.Context()
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	return cs, notes
+}
+
+// TestServer_ForwardsLogsAfterInitialized exercises the end-to-end
+// path: connect a client, raise its log level, drive a record through
+// the server's logger, and assert the client receives a structured
+// logging/message notification.
+func TestServer_ForwardsLogsAfterInitialized(t *testing.T) {
+	var buf bytes.Buffer
+	stderr := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	ts := New()
+	ts.SetLogger(slog.New(stderr))
+
+	cs, notes := captureLoggingClient(t, ts)
+
+	// Raise the threshold so the SDK's LoggingHandler will forward.
+	if err := cs.SetLoggingLevel(t.Context(), &mcp.SetLoggingLevelParams{Level: "debug"}); err != nil {
+		t.Fatalf("SetLoggingLevel: %v", err)
+	}
+
+	// Wait for HandleInitialized to have run and installed the MCP arm.
+	waitForMCPLoggingInstalled(t, ts)
+
+	ts.log().Warn("widget exploded",
+		slog.String("event", "test.forward"),
+		slog.String("widget", "left"),
+	)
+
+	got := waitForLogEvent(t, notes, "test.forward", 2*time.Second)
+	if got.Level != "warning" {
+		t.Errorf("Level = %q, want warning", got.Level)
+	}
+	if got.Logger != "mcp-taskfile-server" {
+		t.Errorf("Logger = %q, want mcp-taskfile-server", got.Logger)
+	}
+	payload := decodePayload(t, got.Data)
+	if payload["widget"] != "left" {
+		t.Errorf("widget = %v, want left", payload["widget"])
+	}
+	if payload["msg"] != "widget exploded" {
+		t.Errorf("msg = %v, want widget exploded", payload["msg"])
+	}
+
+	// Stderr arm must also have received the record.
+	if !strings.Contains(buf.String(), `"event":"test.forward"`) {
+		t.Errorf("stderr buffer missing record; got %s", buf.String())
+	}
+}
+
+// TestServer_RespectsClientLevel verifies that logging/setLevel from
+// the client controls what reaches the MCP arm, while the stderr arm is
+// unaffected.
+func TestServer_RespectsClientLevel(t *testing.T) {
+	var buf bytes.Buffer
+	stderr := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	ts := New()
+	ts.SetLogger(slog.New(stderr))
+
+	cs, notes := captureLoggingClient(t, ts)
+
+	if err := cs.SetLoggingLevel(t.Context(), &mcp.SetLoggingLevelParams{Level: "warning"}); err != nil {
+		t.Fatalf("SetLoggingLevel: %v", err)
+	}
+
+	waitForMCPLoggingInstalled(t, ts)
+	drainNotifications(notes, 100*time.Millisecond)
+
+	ts.log().Info("debugging detail", slog.String("event", "test.suppressed"))
+	ts.log().Error("kaboom", slog.String("event", "test.surfaced"))
+
+	got := waitForLogEvent(t, notes, "test.surfaced", 2*time.Second)
+	if got.Level != "error" {
+		t.Errorf("Level = %q, want error", got.Level)
+	}
+
+	// The suppressed info record must not have crossed the MCP arm.
+	select {
+	case extra := <-notes:
+		payload := decodePayload(t, extra.Data)
+		if payload["event"] == "test.suppressed" {
+			t.Fatalf("info record forwarded despite client level=warning")
+		}
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Stderr arm always sees both records, regardless of client level.
+	if !strings.Contains(buf.String(), `"event":"test.suppressed"`) {
+		t.Errorf("stderr arm missing test.suppressed; got %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"event":"test.surfaced"`) {
+		t.Errorf("stderr arm missing test.surfaced; got %s", buf.String())
+	}
+}
+
+// waitForMCPLoggingInstalled blocks until installMCPLogging has run and
+// extended the server's logger with the SDK arm. It detects the swap by
+// inspecting the handler chain rather than peeking at private state.
+func waitForMCPLoggingInstalled(t *testing.T, ts *Server) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+	for !hasMCPHandler(ts.log().Handler()) {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for installMCPLogging")
+		case <-tick.C:
+		}
+	}
+}
+
+// hasMCPHandler reports whether the given handler tree contains the
+// SDK's LoggingHandler. The fanout handler stores its children in a
+// non-exported field, so we recurse via type assertion only on the
+// types we ourselves construct.
+func hasMCPHandler(h slog.Handler) bool {
+	switch v := h.(type) {
+	case *fanoutHandler:
+		return slices.ContainsFunc(v.handlers, hasMCPHandler)
+	case *mcp.LoggingHandler:
+		return true
+	default:
+		return false
+	}
+}
+
+// drainNotifications consumes any pending notifications for at most d
+// before returning.
+func drainNotifications(ch <-chan *mcp.LoggingMessageParams, d time.Duration) {
+	deadline := time.After(d)
+	for {
+		select {
+		case <-ch:
+		case <-deadline:
+			return
+		}
+	}
+}
+
+// waitForLogEvent blocks until a notification with payload event=name
+// is received or the deadline elapses.
+func waitForLogEvent(t *testing.T, ch <-chan *mcp.LoggingMessageParams, name string, d time.Duration) *mcp.LoggingMessageParams {
+	t.Helper()
+	deadline := time.After(d)
+	for {
+		select {
+		case got := <-ch:
+			payload := decodePayload(t, got.Data)
+			if payload["event"] == name {
+				return got
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for log event %q", name)
+			return nil
+		}
+	}
+}
+
+// decodePayload normalises the LoggingMessageParams.Data value into a
+// map[string]any so assertions can be written without worrying about
+// whether the SDK delivered the original json.RawMessage or a decoded
+// map (varies by transport / JSON round-trip).
+func decodePayload(t *testing.T, data any) map[string]any {
+	t.Helper()
+	switch v := data.(type) {
+	case map[string]any:
+		return v
+	case json.RawMessage:
+		var out map[string]any
+		if err := json.Unmarshal(v, &out); err != nil {
+			t.Fatalf("invalid JSON payload %q: %v", v, err)
+		}
+		return out
+	case []byte:
+		var out map[string]any
+		if err := json.Unmarshal(v, &out); err != nil {
+			t.Fatalf("invalid JSON payload %q: %v", v, err)
+		}
+		return out
+	case string:
+		var out map[string]any
+		if err := json.Unmarshal([]byte(v), &out); err != nil {
+			t.Fatalf("invalid JSON payload %q: %v", v, err)
+		}
+		return out
+	default:
+		t.Fatalf("unexpected payload type %T (%v)", data, data)
+		return nil
+	}
+}
+
+// TestFanoutHandler_DispatchesToAllHandlers verifies the fanout passes
+// every record to each constituent handler.
+func TestFanoutHandler_DispatchesToAllHandlers(t *testing.T) {
+	a := &recordingHandler{}
+	b := &recordingHandler{}
+	logger := slog.New(newFanoutHandler(a, b))
+
+	logger.Warn("ping", slog.String("event", "fanout.test"))
+
+	if got := a.count(); got != 1 {
+		t.Errorf("handler a saw %d records, want 1", got)
+	}
+	if got := b.count(); got != 1 {
+		t.Errorf("handler b saw %d records, want 1", got)
+	}
+}
+
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+
+func (h *recordingHandler) WithGroup(_ string) slog.Handler { return h }
+
+func (h *recordingHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.records)
+}

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -17,8 +17,8 @@ func New() *Server {
 	s := &Server{
 		roots:           make(map[string]*Root),
 		registeredTools: make(map[string]registeredTool),
-		logger:          slog.New(slog.DiscardHandler),
 	}
+	s.logger.Store(slog.New(slog.DiscardHandler))
 	s.watchers = newWatcherManager(s.runRootWatcher)
 	return s
 }
@@ -30,12 +30,32 @@ func (s *Server) SetToolRegistry(registry toolRegistry) {
 
 // SetLogger replaces the structured logger used by the server. Passing
 // a nil logger restores the default silent logger so Server methods can
-// log unconditionally without nil-checking.
+// log unconditionally without nil-checking. The store is atomic so it
+// is safe to call from any goroutine, including after watcher goroutines
+// have started reading the logger.
 func (s *Server) SetLogger(logger *slog.Logger) {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
-	s.logger = logger
+	s.logger.Store(logger)
+}
+
+// installMCPLogging extends the active logger with an MCP arm bound to
+// ss, so subsequent records reach the connected client via
+// logging/message in addition to whatever sink was previously installed
+// (typically a JSON handler on stderr).
+//
+// The SDK's LoggingHandler enforces the client-set threshold internally
+// via logging/setLevel; the stderr arm keeps its own threshold from
+// MCP_TASKFILE_LOG_LEVEL. Failures forwarding to the client are dropped
+// inside the SDK to avoid recursion through this handler.
+func (s *Server) installMCPLogging(ss *mcp.ServerSession) {
+	current := s.log()
+	mcpHandler := mcp.NewLoggingHandler(ss, &mcp.LoggingHandlerOptions{
+		LoggerName: "mcp-taskfile-server",
+	})
+	fanout := newFanoutHandler(current.Handler(), mcpHandler)
+	s.SetLogger(slog.New(fanout))
 }
 
 // isMethodNotFound reports whether err is a JSON-RPC "method not found" error,
@@ -78,7 +98,7 @@ func (s *Server) loadDesired(ctx context.Context, roots []*mcp.Root, existing ma
 	for _, r := range roots {
 		canonicalURI, dir, parseErr := canonicalRootURI(r.URI)
 		if parseErr != nil {
-			s.logger.Warn("skipping root with invalid URI",
+			s.log().Warn("skipping root with invalid URI",
 				slog.String("event", "root.invalid_uri"),
 				slog.String("root_uri", r.URI),
 				slog.Any("error", parseErr),
@@ -95,14 +115,14 @@ func (s *Server) loadDesired(ctx context.Context, roots []*mcp.Root, existing ma
 
 		root, loadErr := loadRoot(ctx, dir)
 		if loadErr != nil {
-			s.logger.Warn("failed to load root, falling back to unloaded placeholder",
+			s.log().Warn("failed to load root, falling back to unloaded placeholder",
 				slog.String("event", "root.load_failed"),
 				slog.String("root_uri", r.URI),
 				slog.Any("error", loadErr),
 			)
 			root, loadErr = newUnloadedRoot(dir)
 			if loadErr != nil {
-				s.logger.Error("failed to watch unloaded root",
+				s.log().Error("failed to watch unloaded root",
 					slog.String("event", "root.unloaded_failed"),
 					slog.String("root_uri", r.URI),
 					slog.Any("error", loadErr),
@@ -240,9 +260,12 @@ func listClientRoots(ctx context.Context, session *mcp.ServerSession) ([]*mcp.Ro
 }
 
 // HandleInitialized is called after the client handshake completes.
+// Before doing any other work it extends the active logger with an MCP
+// arm bound to req.Session so subsequent log records reach the client.
 func (s *Server) HandleInitialized(ctx context.Context, req *mcp.InitializedRequest) {
+	s.installMCPLogging(req.Session)
 	if err := s.initializeRootsFromSession(ctx, req.Session); err != nil {
-		s.logger.Error("failed to initialize roots",
+		s.log().Error("failed to initialize roots",
 			slog.String("event", "roots.init_failed"),
 			slog.Any("error", err),
 		)
@@ -256,7 +279,7 @@ func (s *Server) HandleInitialized(ctx context.Context, req *mcp.InitializedRequ
 func (s *Server) HandleRootsChanged(ctx context.Context, req *mcp.RootsListChangedRequest) {
 	rootRes, err := req.Session.ListRoots(ctx, nil)
 	if err != nil {
-		s.logger.Error("failed to list roots after change",
+		s.log().Error("failed to list roots after change",
 			slog.String("event", "roots.list_failed"),
 			slog.Any("error", err),
 		)
@@ -266,7 +289,7 @@ func (s *Server) HandleRootsChanged(ctx context.Context, req *mcp.RootsListChang
 	res := s.replaceRoots(ctx, rootRes.Roots)
 
 	if err := s.syncTools(); err != nil {
-		s.logger.Error("failed to sync tools after roots change",
+		s.log().Error("failed to sync tools after roots change",
 			slog.String("event", "tools.sync_failed"),
 			slog.Any("error", err),
 		)

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -3,6 +3,7 @@ package taskfileserver
 import (
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-task/task/v3/taskfile/ast"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -44,9 +45,16 @@ type Server struct {
 	toolRegistry    toolRegistry
 	registeredTools map[string]registeredTool
 	watchers        *watcherManager
-	logger          *slog.Logger
+	logger          atomic.Pointer[slog.Logger]
 	mu              sync.Mutex
 	generation      uint64
+}
+
+// log returns the current logger. It is safe to call from any goroutine
+// and never returns nil; New seeds the field with a discard logger and
+// SetLogger preserves that invariant.
+func (s *Server) log() *slog.Logger {
+	return s.logger.Load()
 }
 
 // toolRootSnapshot is an immutable per-root view captured under lock so

--- a/internal/taskfileserver/tools.go
+++ b/internal/taskfileserver/tools.go
@@ -241,7 +241,7 @@ func (s *Server) syncTools() error {
 	s.mu.Unlock()
 
 	// Phase 2: pure planning — no lock held.
-	plan := buildToolPlan(snap, s.logger)
+	plan := buildToolPlan(snap, s.log())
 	stale, added := diffTools(oldTools, plan.tools)
 
 	// Phase 3: validate generation, apply MCP side effects, and commit

--- a/internal/taskfileserver/watch.go
+++ b/internal/taskfileserver/watch.go
@@ -246,7 +246,7 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 		case <-timer.C:
 			timerPending = false
 			if err := s.reloadRoot(ctx, uri); err != nil {
-				s.logger.Error("failed to reload tools for root",
+				s.log().Error("failed to reload tools for root",
 					slog.String("event", "watcher.reload_failed"),
 					slog.String("root_uri", uri),
 					slog.Any("error", err),
@@ -285,7 +285,7 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 			if !ok {
 				return nil
 			}
-			s.logger.Warn("file watcher error",
+			s.log().Warn("file watcher error",
 				slog.String("event", "watcher.fs_error"),
 				slog.String("root_uri", uri),
 				slog.Any("error", err),
@@ -299,7 +299,7 @@ func (s *Server) watchRootTaskfiles(ctx context.Context, uri string) error {
 // take down the manager's bookkeeping.
 func (s *Server) runRootWatcher(ctx context.Context, uri string) {
 	if err := s.watchRootTaskfiles(ctx, uri); err != nil {
-		s.logger.Error("file watcher failed",
+		s.log().Error("file watcher failed",
 			slog.String("event", "watcher.failed"),
 			slog.String("root_uri", uri),
 			slog.Any("error", err),

--- a/main.go
+++ b/main.go
@@ -40,6 +40,11 @@ func parseLogLevel(raw string) slog.Level {
 // newLogger builds the structured logger used by the server. It writes
 // JSON to stderr (the only safe channel under stdio MCP transport) and
 // honours MCP_TASKFILE_LOG_LEVEL.
+//
+// MCP-side mirroring is wired in by the Server itself once the client
+// handshake completes, by extending this logger with the SDK's
+// LoggingHandler bound to the active session. The client controls
+// what reaches it via logging/setLevel, independently of stderr.
 func newLogger() *slog.Logger {
 	level := parseLogLevel(os.Getenv(logLevelEnv))
 	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
@@ -50,17 +55,15 @@ func newLogger() *slog.Logger {
 }
 
 func run() error {
-	logger := newLogger()
-
-	// Create taskfile server
 	taskfileServer := taskfileserver.New()
-	taskfileServer.SetLogger(logger)
+	taskfileServer.SetLogger(newLogger())
 	defer taskfileServer.Shutdown()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Create MCP server with lifecycle handlers
+	// Create MCP server with lifecycle handlers. The default server
+	// capabilities advertised by the SDK already include logging.
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    serverName,
@@ -73,11 +76,6 @@ func run() error {
 	)
 	taskfileServer.SetToolRegistry(mcpServer)
 
-	// Start the stdio server.
-	//
-	// TODO(#98): mirror selected log lines through the MCP `logging`
-	// capability so they reach the client. Tracked separately from #88
-	// (slog migration) and the deferral in commit 84473b2 (#87).
 	if err := mcpServer.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		return fmt.Errorf("server error: %w", err)
 	}


### PR DESCRIPTION
Closes #98 by wiring the Go SDK's `mcp.LoggingHandler` into the server's slog chain so warn/error events (root load failures, watcher reload errors, tool collisions, etc.) reach the connected client via `notifications/message` in addition to stderr. Until now clients had no in-band visibility into server-side diagnostics; the stdio transport reserves stdout for JSON-RPC, so MCP's logging capability is the right channel for surfacing these events.

- Install the SDK's `LoggingHandler` at `HandleInitialized` time and combine it with the existing stderr JSON handler via a small `fanoutHandler` (slog has no built-in multi-handler).
- Switch `Server.logger` to an `atomic.Pointer[slog.Logger]` with a `s.log()` accessor so the handler chain can be extended without racing against watcher goroutines that read it.
- Stderr remains the source of truth, gated by `MCP_TASKFILE_LOG_LEVEL`; the MCP arm is gated independently by the client via `logging/setLevel`, enforced inside the SDK's handler.
- Add tests covering the three acceptance behaviours: no-op before initialization, forwards records once the session is bound, respects client-set level. Stderr arm is asserted to receive every record regardless.
- Drop the TODO(#98) marker in main.go and document the dual-sink behaviour in README.md, including the deliberate 1:1 server-to-session invariant that keeps the design simple and survives a future migration to per-session HTTP via `NewStreamableHTTPHandler.getServer`.

Closes #98