### PR TITLE
refactor: extract internal/logging

### DIFF
--- a/internal/logging/fanout.go
+++ b/internal/logging/fanout.go
@@ -1,29 +1,38 @@
-package taskfileserver
+// Package logging provides the structured logging primitives shared by
+// the Taskfile MCP server: a multi-handler fanout, the MCP "logging"
+// arm wiring, and the stderr logger constructor.
+package logging
 
 import (
 	"context"
 	"log/slog"
 )
 
-// fanoutHandler dispatches every record to multiple slog.Handlers,
+// FanoutHandler dispatches every record to multiple slog.Handlers,
 // allowing the server to emit a single log line to both the stderr JSON
 // sink and the SDK's MCP LoggingHandler without coupling their
 // lifecycles. Per-handler errors are dropped so a failure in one branch
 // does not suppress the others.
 //
 // slog has no built-in multi-handler; this is the minimum needed.
-type fanoutHandler struct {
+type FanoutHandler struct {
 	handlers []slog.Handler
 }
 
-// newFanoutHandler returns a handler that forwards every record to each
-// of handlers in order.
-func newFanoutHandler(handlers ...slog.Handler) *fanoutHandler {
-	return &fanoutHandler{handlers: handlers}
+// NewFanout returns a handler that forwards every record to each of
+// handlers in order.
+func NewFanout(handlers ...slog.Handler) *FanoutHandler {
+	return &FanoutHandler{handlers: handlers}
+}
+
+// Handlers returns the underlying handlers in their original order. The
+// returned slice is shared with the receiver and must not be mutated.
+func (f *FanoutHandler) Handlers() []slog.Handler {
+	return f.handlers
 }
 
 // Enabled reports whether any underlying handler is enabled at level.
-func (f *fanoutHandler) Enabled(ctx context.Context, level slog.Level) bool {
+func (f *FanoutHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	for _, h := range f.handlers {
 		if h.Enabled(ctx, level) {
 			return true
@@ -35,7 +44,7 @@ func (f *fanoutHandler) Enabled(ctx context.Context, level slog.Level) bool {
 // Handle dispatches r to each underlying handler that is enabled.
 // Each handler receives a clone of the record because slog.Record's
 // attributes are encoded lazily.
-func (f *fanoutHandler) Handle(ctx context.Context, r slog.Record) error {
+func (f *FanoutHandler) Handle(ctx context.Context, r slog.Record) error {
 	for _, h := range f.handlers {
 		if !h.Enabled(ctx, r.Level) {
 			continue
@@ -46,19 +55,19 @@ func (f *fanoutHandler) Handle(ctx context.Context, r slog.Record) error {
 }
 
 // WithAttrs implements slog.Handler.
-func (f *fanoutHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+func (f *FanoutHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	cloned := make([]slog.Handler, len(f.handlers))
 	for i, h := range f.handlers {
 		cloned[i] = h.WithAttrs(attrs)
 	}
-	return &fanoutHandler{handlers: cloned}
+	return &FanoutHandler{handlers: cloned}
 }
 
 // WithGroup implements slog.Handler.
-func (f *fanoutHandler) WithGroup(name string) slog.Handler {
+func (f *FanoutHandler) WithGroup(name string) slog.Handler {
 	cloned := make([]slog.Handler, len(f.handlers))
 	for i, h := range f.handlers {
 		cloned[i] = h.WithGroup(name)
 	}
-	return &fanoutHandler{handlers: cloned}
+	return &FanoutHandler{handlers: cloned}
 }

--- a/internal/logging/fanout_test.go
+++ b/internal/logging/fanout_test.go
@@ -1,0 +1,49 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+// TestFanoutHandler_DispatchesToAllHandlers verifies the fanout passes
+// every record to each constituent handler.
+func TestFanoutHandler_DispatchesToAllHandlers(t *testing.T) {
+	a := &recordingHandler{}
+	b := &recordingHandler{}
+	logger := slog.New(NewFanout(a, b))
+
+	logger.Warn("ping", slog.String("event", "fanout.test"))
+
+	if got := a.count(); got != 1 {
+		t.Errorf("handler a saw %d records, want 1", got)
+	}
+	if got := b.count(); got != 1 {
+		t.Errorf("handler b saw %d records, want 1", got)
+	}
+}
+
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+
+func (h *recordingHandler) WithGroup(_ string) slog.Handler { return h }
+
+func (h *recordingHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.records)
+}

--- a/internal/logging/level.go
+++ b/internal/logging/level.go
@@ -1,0 +1,43 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// LevelEnv names the environment variable used to configure the log
+// level. Recognised values: debug, info, warn, error (case-insensitive).
+const LevelEnv = "MCP_TASKFILE_LOG_LEVEL"
+
+// ParseLevel resolves the configured log level. Unrecognised or empty
+// values fall back to info.
+func ParseLevel(raw string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// NewLogger builds the structured logger used by the server. It writes
+// JSON to stderr (the only safe channel under stdio MCP transport) and
+// honours MCP_TASKFILE_LOG_LEVEL.
+//
+// MCP-side mirroring is wired in by the Server itself once the client
+// handshake completes, by extending this logger with the SDK's
+// LoggingHandler bound to the active session via InstallMCP. The client
+// controls what reaches it via logging/setLevel, independently of stderr.
+func NewLogger(serviceName, serviceVersion string) *slog.Logger {
+	level := ParseLevel(os.Getenv(LevelEnv))
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	return slog.New(handler).With(
+		slog.String("service", serviceName),
+		slog.String("version", serviceVersion),
+	)
+}

--- a/internal/logging/level_test.go
+++ b/internal/logging/level_test.go
@@ -1,11 +1,11 @@
-package main
+package logging
 
 import (
 	"log/slog"
 	"testing"
 )
 
-func TestParseLogLevel(t *testing.T) {
+func TestParseLevel(t *testing.T) {
 	cases := []struct {
 		raw  string
 		want slog.Level
@@ -23,8 +23,8 @@ func TestParseLogLevel(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.raw, func(t *testing.T) {
-			if got := parseLogLevel(tc.raw); got != tc.want {
-				t.Errorf("parseLogLevel(%q) = %v, want %v", tc.raw, got, tc.want)
+			if got := ParseLevel(tc.raw); got != tc.want {
+				t.Errorf("ParseLevel(%q) = %v, want %v", tc.raw, got, tc.want)
 			}
 		})
 	}

--- a/internal/logging/mcp.go
+++ b/internal/logging/mcp.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// LoggerName is the logger name reported on logging/message
+// notifications sent to the connected MCP client.
+const LoggerName = "mcp-taskfile-server"
+
+// InstallMCP returns a logger derived from parent that fans every
+// record out to both parent's existing handler and an MCP arm bound to
+// ss. Subsequent records reach the connected client via logging/message
+// in addition to whatever sink was previously installed (typically a
+// JSON handler on stderr).
+//
+// The SDK's LoggingHandler enforces the client-set threshold internally
+// via logging/setLevel; the parent arm keeps its own threshold from
+// MCP_TASKFILE_LOG_LEVEL. Failures forwarding to the client are dropped
+// inside the SDK to avoid recursion through this handler.
+func InstallMCP(parent *slog.Logger, ss *mcp.ServerSession) *slog.Logger {
+	mcpHandler := mcp.NewLoggingHandler(ss, &mcp.LoggingHandlerOptions{
+		LoggerName: LoggerName,
+	})
+	return slog.New(NewFanout(parent.Handler(), mcpHandler))
+}

--- a/internal/taskfileserver/logging_mcp_test.go
+++ b/internal/taskfileserver/logging_mcp_test.go
@@ -7,11 +7,11 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rsclarke/mcp-taskfile-server/internal/logging"
 )
 
 // TestServer_NoMCPLoggingBeforeInitialized verifies that a freshly
@@ -192,13 +192,13 @@ func waitForMCPLoggingInstalled(t *testing.T, ts *Server) {
 }
 
 // hasMCPHandler reports whether the given handler tree contains the
-// SDK's LoggingHandler. The fanout handler stores its children in a
-// non-exported field, so we recurse via type assertion only on the
-// types we ourselves construct.
+// SDK's LoggingHandler. The fanout handler exposes its children via
+// Handlers, so we recurse via type assertion only on the types we
+// ourselves construct.
 func hasMCPHandler(h slog.Handler) bool {
 	switch v := h.(type) {
-	case *fanoutHandler:
-		return slices.ContainsFunc(v.handlers, hasMCPHandler)
+	case *logging.FanoutHandler:
+		return slices.ContainsFunc(v.Handlers(), hasMCPHandler)
 	case *mcp.LoggingHandler:
 		return true
 	default:
@@ -269,45 +269,4 @@ func decodePayload(t *testing.T, data any) map[string]any {
 		t.Fatalf("unexpected payload type %T (%v)", data, data)
 		return nil
 	}
-}
-
-// TestFanoutHandler_DispatchesToAllHandlers verifies the fanout passes
-// every record to each constituent handler.
-func TestFanoutHandler_DispatchesToAllHandlers(t *testing.T) {
-	a := &recordingHandler{}
-	b := &recordingHandler{}
-	logger := slog.New(newFanoutHandler(a, b))
-
-	logger.Warn("ping", slog.String("event", "fanout.test"))
-
-	if got := a.count(); got != 1 {
-		t.Errorf("handler a saw %d records, want 1", got)
-	}
-	if got := b.count(); got != 1 {
-		t.Errorf("handler b saw %d records, want 1", got)
-	}
-}
-
-type recordingHandler struct {
-	mu      sync.Mutex
-	records []slog.Record
-}
-
-func (h *recordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
-
-func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.records = append(h.records, r)
-	return nil
-}
-
-func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
-
-func (h *recordingHandler) WithGroup(_ string) slog.Handler { return h }
-
-func (h *recordingHandler) count() int {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return len(h.records)
 }

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rsclarke/mcp-taskfile-server/internal/logging"
 )
 
 // New creates a new Taskfile MCP server. The server starts with a
@@ -38,24 +39,6 @@ func (s *Server) SetLogger(logger *slog.Logger) {
 		logger = slog.New(slog.DiscardHandler)
 	}
 	s.logger.Store(logger)
-}
-
-// installMCPLogging extends the active logger with an MCP arm bound to
-// ss, so subsequent records reach the connected client via
-// logging/message in addition to whatever sink was previously installed
-// (typically a JSON handler on stderr).
-//
-// The SDK's LoggingHandler enforces the client-set threshold internally
-// via logging/setLevel; the stderr arm keeps its own threshold from
-// MCP_TASKFILE_LOG_LEVEL. Failures forwarding to the client are dropped
-// inside the SDK to avoid recursion through this handler.
-func (s *Server) installMCPLogging(ss *mcp.ServerSession) {
-	current := s.log()
-	mcpHandler := mcp.NewLoggingHandler(ss, &mcp.LoggingHandlerOptions{
-		LoggerName: "mcp-taskfile-server",
-	})
-	fanout := newFanoutHandler(current.Handler(), mcpHandler)
-	s.SetLogger(slog.New(fanout))
 }
 
 // isMethodNotFound reports whether err is a JSON-RPC "method not found" error,
@@ -263,7 +246,7 @@ func listClientRoots(ctx context.Context, session *mcp.ServerSession) ([]*mcp.Ro
 // Before doing any other work it extends the active logger with an MCP
 // arm bound to req.Session so subsequent log records reach the client.
 func (s *Server) HandleInitialized(ctx context.Context, req *mcp.InitializedRequest) {
-	s.installMCPLogging(req.Session)
+	s.SetLogger(logging.InstallMCP(s.log(), req.Session))
 	if err := s.initializeRootsFromSession(ctx, req.Session); err != nil {
 		s.log().Error("failed to initialize roots",
 			slog.String("event", "roots.init_failed"),

--- a/main.go
+++ b/main.go
@@ -4,11 +4,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rsclarke/mcp-taskfile-server/internal/logging"
 	"github.com/rsclarke/mcp-taskfile-server/internal/taskfileserver"
 )
 
@@ -18,45 +17,9 @@ var (
 	serverVersion = "dev"
 )
 
-// logLevelEnv names the environment variable used to configure the log
-// level. Recognised values: debug, info, warn, error (case-insensitive).
-const logLevelEnv = "MCP_TASKFILE_LOG_LEVEL"
-
-// parseLogLevel resolves the configured log level. Unrecognised or empty
-// values fall back to info.
-func parseLogLevel(raw string) slog.Level {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "debug":
-		return slog.LevelDebug
-	case "warn", "warning":
-		return slog.LevelWarn
-	case "error":
-		return slog.LevelError
-	default:
-		return slog.LevelInfo
-	}
-}
-
-// newLogger builds the structured logger used by the server. It writes
-// JSON to stderr (the only safe channel under stdio MCP transport) and
-// honours MCP_TASKFILE_LOG_LEVEL.
-//
-// MCP-side mirroring is wired in by the Server itself once the client
-// handshake completes, by extending this logger with the SDK's
-// LoggingHandler bound to the active session. The client controls
-// what reaches it via logging/setLevel, independently of stderr.
-func newLogger() *slog.Logger {
-	level := parseLogLevel(os.Getenv(logLevelEnv))
-	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
-	return slog.New(handler).With(
-		slog.String("service", serverName),
-		slog.String("version", serverVersion),
-	)
-}
-
 func run() error {
 	taskfileServer := taskfileserver.New()
-	taskfileServer.SetLogger(newLogger())
+	taskfileServer.SetLogger(logging.NewLogger(serverName, serverVersion))
 	defer taskfileServer.Shutdown()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Phase A of the taskfileserver split (#80): extract the logging primitives that have no Server coupling into a new `internal/logging` package. This is the smallest, leafiest phase and serves as a dry run for the toolchain (git mv, import paths, lint/test) before tackling roots, exec, tools, and watch.

**What moved into `internal/logging`:**

- `fanoutHandler` / `newFanoutHandler` (formerly `internal/taskfileserver/logging.go`) → `fanout.go`, exported as `FanoutHandler` / `NewFanout`. A new `Handlers()` accessor lets external test code walk the handler tree without poking unexported state.
- `Server.installMCPLogging` → `logging.InstallMCP(*slog.Logger, *mcp.ServerSession) *slog.Logger`, plus the `logging.LoggerName` constant. `HandleInitialized` now calls it inline.
- `parseLogLevel` / `newLogger` from `main.go` → `logging.ParseLevel` / `logging.NewLogger`. `MCP_TASKFILE_LOG_LEVEL` lives on as `logging.LevelEnv`.
- `main_test.go` → `internal/logging/level_test.go` (git mv preserves history).
- `TestFanoutHandler_DispatchesToAllHandlers` and `recordingHandler` → `internal/logging/fanout_test.go`.

**What stayed in `internal/taskfileserver`:**

The `TestSetLogger_*` and `TestServer_*` tests in `logging_test.go` and `logging_mcp_test.go` exercise unexported helpers (`Server.loadDesired`, `Server.log`) so they remain co-located with the `Server` they characterise. They now reference `*logging.FanoutHandler` in the type assertion.

**No behaviour change.** Log levels, the `MCP_TASKFILE_LOG_LEVEL` env var, structured field names, the MCP logger name (`mcp-taskfile-server`), and handler ordering are all unchanged. `task ci` and `task build` are green.

Refs #80