### PR TITLE
refactor: extract internal/roots

### DIFF
--- a/internal/roots/load.go
+++ b/internal/roots/load.go
@@ -1,0 +1,82 @@
+// Package roots loads and represents the Taskfile graphs for one or more
+// workspace roots. It is the single owner of the *Root value type and
+// contains all URI canonicalisation and Taskfile graph parsing helpers.
+//
+// This package must not import the MCP SDK; it is consumed by the server
+// package, which adapts roots.Root values into MCP state.
+package roots
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-task/task/v3"
+	"github.com/go-task/task/v3/taskfile"
+)
+
+// Build resolves the Taskfile graph for workdir, sets up a task
+// executor, and returns a fully populated *Root. workdir must already be
+// an absolute path.
+func Build(ctx context.Context, workdir string) (*Root, error) {
+	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, workdir)
+	if err != nil {
+		return nil, err
+	}
+
+	executor := task.NewExecutor(
+		task.WithDir(workdir),
+		task.WithEntrypoint(entrypoint),
+		task.WithSilent(true),
+	)
+	if err := executor.Setup(); err != nil {
+		return nil, fmt.Errorf("failed to setup task executor for %s: %w", workdir, err)
+	}
+
+	return &Root{
+		Taskfile:       executor.Taskfile,
+		Workdir:        workdir,
+		WatchDirs:      watchDirs,
+		WatchTaskfiles: watchTaskfiles,
+	}, nil
+}
+
+// Load creates a new Root by loading the Taskfile from the given directory.
+func Load(ctx context.Context, dir string) (*Root, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	return Build(ctx, abs)
+}
+
+// NewUnloaded creates a root placeholder for a workspace that does not
+// yet have a loadable root Taskfile. Watching the root directory lets
+// callers pick up a Taskfile that is created or fixed after startup.
+func NewUnloaded(dir string) (*Root, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat root %s: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root %s is not a directory", abs)
+	}
+
+	watchTaskfiles := make(map[string]struct{}, len(taskfile.DefaultTaskfiles))
+	for _, filename := range taskfile.DefaultTaskfiles {
+		watchTaskfiles[filepath.Join(abs, filename)] = struct{}{}
+	}
+
+	return &Root{
+		Workdir:        abs,
+		WatchDirs:      []string{abs},
+		WatchTaskfiles: watchTaskfiles,
+	}, nil
+}

--- a/internal/roots/root.go
+++ b/internal/roots/root.go
@@ -1,0 +1,21 @@
+package roots
+
+import "github.com/go-task/task/v3/taskfile/ast"
+
+// Root holds the loaded per-root Taskfile data. Once a *Root is published
+// to a consumer (e.g. a server's roots map) its fields are treated as
+// read-only; mutations are performed by replacing the pointer rather than
+// writing through the existing value, so concurrent readers (snapshots,
+// watchers) always observe a consistent state. *Root values therefore
+// must NOT be mutated by code outside of construction sites in this
+// package.
+//
+// The fields are exported because reconcile, tool planning, and watcher
+// code lives in other packages and needs to read them. They are still
+// considered immutable after construction.
+type Root struct {
+	Taskfile       *ast.Taskfile
+	Workdir        string
+	WatchDirs      []string
+	WatchTaskfiles map[string]struct{}
+}

--- a/internal/roots/roots_test.go
+++ b/internal/roots/roots_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package roots
 
 import (
 	"os"
@@ -50,9 +50,9 @@ func TestDirToURI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	uri := dirToURI(dir)
+	uri := DirToURI(dir)
 	if strings.Contains(uri, "#") || strings.Contains(uri, "?") {
-		t.Fatalf("dirToURI(%q) returned unescaped URI %q", dir, uri)
+		t.Fatalf("DirToURI(%q) returned unescaped URI %q", dir, uri)
 	}
 
 	roundTrip, err := fileURIToPath(uri)
@@ -70,7 +70,7 @@ func TestFileURIToPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := filepath.Clean(dir)
-	uri := dirToURI(dir)
+	uri := DirToURI(dir)
 	localhostURI := strings.Replace(uri, "file://", "file://localhost", 1)
 
 	tests := []struct {
@@ -130,7 +130,7 @@ func TestCanonicalRootURI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantURI := dirToURI(dir)
+	wantURI := DirToURI(dir)
 	wantDir := filepath.Clean(dir)
 	aliasURI := strings.Replace(wantURI, "file://", "file://localhost", 1)
 
@@ -144,21 +144,21 @@ func TestCanonicalRootURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURI, gotDir, err := canonicalRootURI(tt.uri)
+			gotURI, gotDir, err := CanonicalRootURI(tt.uri)
 			if err != nil {
-				t.Fatalf("canonicalRootURI(%q) failed: %v", tt.uri, err)
+				t.Fatalf("CanonicalRootURI(%q) failed: %v", tt.uri, err)
 			}
 			if gotURI != wantURI {
-				t.Fatalf("canonicalRootURI(%q) URI = %q, want %q", tt.uri, gotURI, wantURI)
+				t.Fatalf("CanonicalRootURI(%q) URI = %q, want %q", tt.uri, gotURI, wantURI)
 			}
 			if gotDir != wantDir {
-				t.Fatalf("canonicalRootURI(%q) dir = %q, want %q", tt.uri, gotDir, wantDir)
+				t.Fatalf("CanonicalRootURI(%q) dir = %q, want %q", tt.uri, gotDir, wantDir)
 			}
 		})
 	}
 }
 
-func TestLoadRoot_DoesNotWalkParentDirectories(t *testing.T) {
+func TestLoad_DoesNotWalkParentDirectories(t *testing.T) {
 	parent := t.TempDir()
 	if err := os.WriteFile(filepath.Join(parent, "Taskfile.yml"), []byte("version: '3'\ntasks:\n  parent:\n    cmds:\n      - echo parent\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -169,8 +169,8 @@ func TestLoadRoot_DoesNotWalkParentDirectories(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := loadRoot(t.Context(), child); err == nil {
-		t.Fatal("expected loadRoot to fail when the root has no direct Taskfile")
+	if _, err := Load(t.Context(), child); err == nil {
+		t.Fatal("expected Load to fail when the root has no direct Taskfile")
 	}
 }
 
@@ -180,7 +180,7 @@ func TestTaskfileLocationToPath_FileURI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, ok, err := taskfileLocationToPath(dirToURI(dir))
+	got, ok, err := taskfileLocationToPath(DirToURI(dir))
 	if err != nil {
 		t.Fatalf("taskfileLocationToPath failed: %v", err)
 	}
@@ -199,27 +199,5 @@ func TestTaskfileLocationToPath_IgnoresNonLocalURI(t *testing.T) {
 	}
 	if ok {
 		t.Fatalf("expected non-file URI to be ignored, got %q", got)
-	}
-}
-
-func TestSanitizeRootPrefix(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"myproject", "myproject"},
-		{"my project", "my_project"},
-		{"my/project", "my_project"},
-		{"___", "root"},
-		{"", "root"},
-		{"a-b.c_d", "a-b.c_d"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := sanitizeRootPrefix(tt.input)
-			if got != tt.want {
-				t.Errorf("sanitizeRootPrefix(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-		})
 	}
 }

--- a/internal/roots/taskgraph.go
+++ b/internal/roots/taskgraph.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package roots
 
 import (
 	"context"

--- a/internal/roots/uri.go
+++ b/internal/roots/uri.go
@@ -1,0 +1,75 @@
+package roots
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// DirToURI converts an absolute directory path to a file:// URI.
+func DirToURI(dir string) string {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		abs = dir
+	}
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}).String()
+}
+
+// CanonicalRootURI resolves a client-provided local file URI to the canonical
+// absolute file URI we use as the server's internal root identity. Equivalent
+// aliases such as file:///repo and file://localhost/repo collapse to the same
+// canonical URI and directory.
+func CanonicalRootURI(raw string) (string, string, error) {
+	dir, err := fileURIToPath(raw)
+	if err != nil {
+		return "", "", err
+	}
+
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve path for %q: %w", raw, err)
+	}
+
+	return DirToURI(abs), abs, nil
+}
+
+// fileURIToPath parses a local file:// URI into a filesystem path.
+func fileURIToPath(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid URI %q: %w", raw, err)
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("unsupported URI scheme %q (only file:// is supported)", u.Scheme)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("file URI %q must not include query or fragment", raw)
+	}
+	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
+		return "", fmt.Errorf("UNC file URI %q is not supported", raw)
+	}
+
+	path := u.Path
+	if path == "" {
+		return "", fmt.Errorf("file URI %q is missing a path", raw)
+	}
+	if isWindowsDriveURIPath(path) {
+		if runtime.GOOS != "windows" {
+			return "", fmt.Errorf("windows file URI %q is not supported on %s", raw, runtime.GOOS)
+		}
+		path = strings.TrimPrefix(path, "/")
+	}
+
+	return filepath.Clean(filepath.FromSlash(path)), nil
+}
+
+func isWindowsDriveURIPath(path string) bool {
+	if len(path) < 3 || path[0] != '/' || path[2] != ':' {
+		return false
+	}
+
+	drive := path[1]
+	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
+}

--- a/internal/taskfileserver/execute_test.go
+++ b/internal/taskfileserver/execute_test.go
@@ -92,7 +92,7 @@ func TestCreateTaskHandlerForWorkdir_WildcardMATCH(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := createTaskHandlerForWorkdir(root.workdir, tt.taskName)
+			handler := createTaskHandlerForWorkdir(root.Workdir, tt.taskName)
 			result := callToolHandler(t, handler, tt.toolName, tt.arguments)
 
 			if result.IsError != tt.wantError {
@@ -113,7 +113,7 @@ func TestCreateTaskHandlerForWorkdir_InvalidArguments(t *testing.T) {
 	s := loadServerFromFixture(t, "basic")
 	root := onlyRoot(t, s)
 
-	handler := createTaskHandlerForWorkdir(root.workdir, "greet")
+	handler := createTaskHandlerForWorkdir(root.Workdir, "greet")
 	args := json.RawMessage(`{invalid json}`)
 	result, err := handler(t.Context(), &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{
@@ -138,7 +138,7 @@ func TestCreateTaskHandlerForWorkdir_StructuredSuccessContent(t *testing.T) {
 	s := newTempServer(t, []byte("version: '3'\ntasks:\n  noisy:\n    desc: Emit on both streams\n    cmds:\n      - sh -c 'echo out-line; echo err-line 1>&2'\n"))
 	root := onlyRoot(t, s)
 
-	handler := createTaskHandlerForWorkdir(root.workdir, "noisy")
+	handler := createTaskHandlerForWorkdir(root.Workdir, "noisy")
 	result := callToolHandler(t, handler, "noisy", nil)
 
 	if result.IsError {
@@ -174,7 +174,7 @@ func TestCreateTaskHandlerForWorkdir_StructuredFailureContent(t *testing.T) {
 	s := newTempServer(t, []byte("version: '3'\ntasks:\n  fail:\n    desc: Fail with both streams\n    cmds:\n      - sh -c 'echo before-fail; echo bad-news 1>&2; exit 7'\n"))
 	root := onlyRoot(t, s)
 
-	handler := createTaskHandlerForWorkdir(root.workdir, "fail")
+	handler := createTaskHandlerForWorkdir(root.Workdir, "fail")
 	result := callToolHandler(t, handler, "fail", nil)
 
 	if !result.IsError {
@@ -198,7 +198,7 @@ func TestCreateTaskHandlerForWorkdir_StructuredSilentSuccess(t *testing.T) {
 	s := newTempServer(t, []byte("version: '3'\ntasks:\n  quiet:\n    desc: A task with no output\n    cmds:\n      - 'true'\n"))
 	root := onlyRoot(t, s)
 
-	handler := createTaskHandlerForWorkdir(root.workdir, "quiet")
+	handler := createTaskHandlerForWorkdir(root.Workdir, "quiet")
 	result := callToolHandler(t, handler, "quiet", nil)
 
 	if result.IsError {

--- a/internal/taskfileserver/integration_test.go
+++ b/internal/taskfileserver/integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
 
 func TestHandleInitialized_WithRoots(t *testing.T) {
@@ -22,7 +23,7 @@ func TestHandleInitialized_WithRoots(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	rootURI := dirToURI(dir)
+	rootURI := roots.DirToURI(dir)
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(&mcp.Root{URI: rootURI, Name: "test"})
 
@@ -89,7 +90,7 @@ func TestHandleInitialized_CallToolExecutesSingleRootTool(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	rootURI := dirToURI(dir)
+	rootURI := roots.DirToURI(dir)
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(&mcp.Root{URI: rootURI, Name: "test"})
 
@@ -141,7 +142,7 @@ func TestHandleInitialized_DeduplicatesEquivalentRootURIs(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	rootURI := dirToURI(dir)
+	rootURI := roots.DirToURI(dir)
 	aliasURI := strings.Replace(rootURI, "file://", "file://localhost", 1)
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(
@@ -204,8 +205,8 @@ func TestHandleRootsChanged_AddAndRemove(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	uri1 := dirToURI(dir1)
-	uri2 := dirToURI(dir2)
+	uri1 := roots.DirToURI(dir1)
+	uri2 := roots.DirToURI(dir2)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(&mcp.Root{URI: uri1, Name: "root1"})
@@ -270,7 +271,7 @@ func TestHandleRootsChanged_EquivalentURIAliasKeepsSingleRoot(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	rootURI := dirToURI(dir)
+	rootURI := roots.DirToURI(dir)
 	aliasURI := strings.Replace(rootURI, "file://", "file://localhost", 1)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
@@ -357,7 +358,7 @@ func TestHandleInitialized_NoPublicTasks(t *testing.T) {
 
 	ts := New()
 	ctx := t.Context()
-	uri := dirToURI(dir)
+	uri := roots.DirToURI(dir)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(&mcp.Root{URI: uri, Name: "root"})
@@ -407,8 +408,8 @@ func TestHandleRootsChanged_TransitionToUnprefixed(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	uri1 := dirToURI(dir1)
-	uri2 := dirToURI(dir2)
+	uri1 := roots.DirToURI(dir1)
+	uri2 := roots.DirToURI(dir2)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(
@@ -475,8 +476,8 @@ func TestHandleRootsChanged_TransitionToUnprefixedCallTool(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	uri1 := dirToURI(dir1)
-	uri2 := dirToURI(dir2)
+	uri1 := roots.DirToURI(dir1)
+	uri2 := roots.DirToURI(dir2)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(
@@ -541,7 +542,7 @@ func TestHandleRootsChanged_RemoveLastRootClearsTools(t *testing.T) {
 
 	ts := New()
 	ctx := t.Context()
-	uri := dirToURI(dir)
+	uri := roots.DirToURI(dir)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
 	client.AddRoots(&mcp.Root{URI: uri, Name: "root"})
@@ -593,7 +594,7 @@ func TestToolListChangedNotification_OnFileChange(t *testing.T) {
 	ts := New()
 	ctx := t.Context()
 
-	rootURI := dirToURI(dir)
+	rootURI := roots.DirToURI(dir)
 
 	// Track notifications received by the client.
 	notified := make(chan struct{}, 10)

--- a/internal/taskfileserver/naming_test.go
+++ b/internal/taskfileserver/naming_test.go
@@ -1,0 +1,25 @@
+package taskfileserver
+
+import "testing"
+
+func TestSanitizeRootPrefix(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"myproject", "myproject"},
+		{"my project", "my_project"},
+		{"my/project", "my_project"},
+		{"___", "root"},
+		{"", "root"},
+		{"a-b.c_d", "a-b.c_d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeRootPrefix(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeRootPrefix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/taskfileserver/reconcile_test.go
+++ b/internal/taskfileserver/reconcile_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
 
 // writeTaskfile creates a directory with a Taskfile that defines a single
@@ -16,7 +18,7 @@ func writeTaskfile(t *testing.T, name string) string {
 	if err := os.WriteFile(filepath.Join(dir, "Taskfile.yml"), body, 0o600); err != nil {
 		t.Fatalf("write Taskfile: %v", err)
 	}
-	return dirToURI(dir)
+	return roots.DirToURI(dir)
 }
 
 // newReconcileServer returns a Server suitable for reconcile tests: it has

--- a/internal/taskfileserver/roots.go
+++ b/internal/taskfileserver/roots.go
@@ -4,146 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 
-	"github.com/go-task/task/v3"
-	"github.com/go-task/task/v3/taskfile"
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
-
-// dirToURI converts an absolute directory path to a file:// URI.
-func dirToURI(dir string) string {
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		abs = dir
-	}
-	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}).String()
-}
-
-// canonicalRootURI resolves a client-provided local file URI to the canonical
-// absolute file URI we use as the server's internal root identity. Equivalent
-// aliases such as file:///repo and file://localhost/repo collapse to the same
-// canonical URI and directory.
-func canonicalRootURI(raw string) (string, string, error) {
-	dir, err := fileURIToPath(raw)
-	if err != nil {
-		return "", "", err
-	}
-
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to resolve path for %q: %w", raw, err)
-	}
-
-	return dirToURI(abs), abs, nil
-}
-
-// fileURIToPath parses a local file:// URI into a filesystem path.
-func fileURIToPath(raw string) (string, error) {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return "", fmt.Errorf("invalid URI %q: %w", raw, err)
-	}
-	if u.Scheme != "file" {
-		return "", fmt.Errorf("unsupported URI scheme %q (only file:// is supported)", u.Scheme)
-	}
-	if u.RawQuery != "" || u.Fragment != "" {
-		return "", fmt.Errorf("file URI %q must not include query or fragment", raw)
-	}
-	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
-		return "", fmt.Errorf("UNC file URI %q is not supported", raw)
-	}
-
-	path := u.Path
-	if path == "" {
-		return "", fmt.Errorf("file URI %q is missing a path", raw)
-	}
-	if isWindowsDriveURIPath(path) {
-		if runtime.GOOS != "windows" {
-			return "", fmt.Errorf("windows file URI %q is not supported on %s", raw, runtime.GOOS)
-		}
-		path = strings.TrimPrefix(path, "/")
-	}
-
-	return filepath.Clean(filepath.FromSlash(path)), nil
-}
-
-func isWindowsDriveURIPath(path string) bool {
-	if len(path) < 3 || path[0] != '/' || path[2] != ':' {
-		return false
-	}
-
-	drive := path[1]
-	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
-}
-
-// buildRoot resolves the Taskfile graph for workdir, sets up a task
-// executor, and returns a fully populated *Root. workdir must already be
-// an absolute path.
-func buildRoot(ctx context.Context, workdir string) (*Root, error) {
-	entrypoint, watchTaskfiles, watchDirs, err := loadTaskfileWatchSet(ctx, workdir)
-	if err != nil {
-		return nil, err
-	}
-
-	executor := task.NewExecutor(
-		task.WithDir(workdir),
-		task.WithEntrypoint(entrypoint),
-		task.WithSilent(true),
-	)
-	if err := executor.Setup(); err != nil {
-		return nil, fmt.Errorf("failed to setup task executor for %s: %w", workdir, err)
-	}
-
-	return &Root{
-		taskfile:       executor.Taskfile,
-		workdir:        workdir,
-		watchDirs:      watchDirs,
-		watchTaskfiles: watchTaskfiles,
-	}, nil
-}
-
-// loadRoot creates a new Root by loading the Taskfile from the given directory.
-func loadRoot(ctx context.Context, dir string) (*Root, error) {
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve path: %w", err)
-	}
-
-	return buildRoot(ctx, abs)
-}
-
-// newUnloadedRoot creates a root placeholder for a workspace that does not yet
-// have a loadable root Taskfile. Watching the root directory lets us pick up a
-// Taskfile that is created or fixed after startup.
-func newUnloadedRoot(dir string) (*Root, error) {
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve path: %w", err)
-	}
-
-	info, err := os.Stat(abs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to stat root %s: %w", abs, err)
-	}
-	if !info.IsDir() {
-		return nil, fmt.Errorf("root %s is not a directory", abs)
-	}
-
-	watchTaskfiles := make(map[string]struct{}, len(taskfile.DefaultTaskfiles))
-	for _, filename := range taskfile.DefaultTaskfiles {
-		watchTaskfiles[filepath.Join(abs, filename)] = struct{}{}
-	}
-
-	return &Root{
-		workdir:        abs,
-		watchDirs:      []string{abs},
-		watchTaskfiles: watchTaskfiles,
-	}, nil
-}
 
 // unloadRoot removes the root with the given canonical URI from the
 // server's in-memory map. The caller must hold s.mu.
@@ -162,11 +25,11 @@ func (s *Server) unloadRoot(uri string) {
 // bumps the generation. Replacing rather than mutating keeps Root values
 // reachable from prior snapshots effectively immutable. The caller must
 // hold s.mu and is responsible for running syncTools afterwards.
-func (s *Server) disableRootToolsLocked(uri string, root *Root) {
-	s.roots[uri] = &Root{
-		workdir:        root.workdir,
-		watchDirs:      root.watchDirs,
-		watchTaskfiles: root.watchTaskfiles,
+func (s *Server) disableRootToolsLocked(uri string, root *roots.Root) {
+	s.roots[uri] = &roots.Root{
+		Workdir:        root.Workdir,
+		WatchDirs:      root.WatchDirs,
+		WatchTaskfiles: root.WatchTaskfiles,
 	}
 	s.generation++
 }
@@ -180,10 +43,10 @@ func (s *Server) reloadRoot(ctx context.Context, uri string) error {
 		s.mu.Unlock()
 		return fmt.Errorf("unknown root %q", uri)
 	}
-	workdir := root.workdir
+	workdir := root.Workdir
 	s.mu.Unlock()
 
-	newRoot, err := buildRoot(ctx, workdir)
+	newRoot, err := roots.Build(ctx, workdir)
 	if err != nil {
 		s.mu.Lock()
 		s.disableRootToolsLocked(uri, root)

--- a/internal/taskfileserver/server.go
+++ b/internal/taskfileserver/server.go
@@ -10,13 +10,14 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rsclarke/mcp-taskfile-server/internal/logging"
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
 
 // New creates a new Taskfile MCP server. The server starts with a
 // silent logger; callers should override it via SetLogger before Run.
 func New() *Server {
 	s := &Server{
-		roots:           make(map[string]*Root),
+		roots:           make(map[string]*roots.Root),
 		registeredTools: make(map[string]registeredTool),
 	}
 	s.logger.Store(slog.New(slog.DiscardHandler))
@@ -72,14 +73,14 @@ func (r reconcileResult) changed() bool {
 // failures that cannot fall back to an unloaded placeholder are logged and
 // skipped.
 //
-// This helper performs disk I/O (loadRoot, newUnloadedRoot) and MUST be
-// called without s.mu held.
-func (s *Server) loadDesired(ctx context.Context, roots []*mcp.Root, existing map[string]struct{}) (map[string]struct{}, map[string]*Root) {
-	desiredURIs := make(map[string]struct{}, len(roots))
-	loadedRoots := make(map[string]*Root, len(roots))
+// This helper performs disk I/O (roots.Load, roots.NewUnloaded) and MUST
+// be called without s.mu held.
+func (s *Server) loadDesired(ctx context.Context, mcpRoots []*mcp.Root, existing map[string]struct{}) (map[string]struct{}, map[string]*roots.Root) {
+	desiredURIs := make(map[string]struct{}, len(mcpRoots))
+	loadedRoots := make(map[string]*roots.Root, len(mcpRoots))
 
-	for _, r := range roots {
-		canonicalURI, dir, parseErr := canonicalRootURI(r.URI)
+	for _, r := range mcpRoots {
+		canonicalURI, dir, parseErr := roots.CanonicalRootURI(r.URI)
 		if parseErr != nil {
 			s.log().Warn("skipping root with invalid URI",
 				slog.String("event", "root.invalid_uri"),
@@ -96,14 +97,14 @@ func (s *Server) loadDesired(ctx context.Context, roots []*mcp.Root, existing ma
 			continue
 		}
 
-		root, loadErr := loadRoot(ctx, dir)
+		root, loadErr := roots.Load(ctx, dir)
 		if loadErr != nil {
 			s.log().Warn("failed to load root, falling back to unloaded placeholder",
 				slog.String("event", "root.load_failed"),
 				slog.String("root_uri", r.URI),
 				slog.Any("error", loadErr),
 			)
-			root, loadErr = newUnloadedRoot(dir)
+			root, loadErr = roots.NewUnloaded(dir)
 			if loadErr != nil {
 				s.log().Error("failed to watch unloaded root",
 					slog.String("event", "root.unloaded_failed"),
@@ -239,7 +240,7 @@ func listClientRoots(ctx context.Context, session *mcp.ServerSession) ([]*mcp.Ro
 	if wdErr != nil {
 		return nil, fmt.Errorf("failed to get working directory: %w", wdErr)
 	}
-	return []*mcp.Root{{URI: dirToURI(workdir)}}, nil
+	return []*mcp.Root{{URI: roots.DirToURI(workdir)}}, nil
 }
 
 // HandleInitialized is called after the client handshake completes.

--- a/internal/taskfileserver/state.go
+++ b/internal/taskfileserver/state.go
@@ -7,20 +7,8 @@ import (
 
 	"github.com/go-task/task/v3/taskfile/ast"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
-
-// Root holds the loaded per-root Taskfile data. Once a *Root is published
-// into Server.roots its fields are treated as read-only; mutations are
-// performed by replacing the pointer in the map rather than writing
-// through the existing value, so concurrent readers (snapshots, watchers)
-// always observe a consistent state. *Root values therefore must NOT be
-// mutated outside roots.go.
-type Root struct {
-	taskfile       *ast.Taskfile
-	workdir        string
-	watchDirs      []string
-	watchTaskfiles map[string]struct{}
-}
 
 // toolRegistry is the subset of *mcp.Server used for tool registration.
 type toolRegistry interface {
@@ -41,7 +29,7 @@ type toolRegistry interface {
 // and lifecycle that is independent of mu. Callers must not hold mu
 // while invoking watcher methods.
 type Server struct {
-	roots           map[string]*Root
+	roots           map[string]*roots.Root
 	toolRegistry    toolRegistry
 	registeredTools map[string]registeredTool
 	watchers        *watcherManager
@@ -60,7 +48,7 @@ func (s *Server) log() *slog.Logger {
 // toolRootSnapshot is an immutable per-root view captured under lock so
 // the planner can run without holding s.mu and without dereferencing a
 // live *Root that another goroutine may mutate. The taskfile pointer is
-// captured by value: even if reloadRoot later swaps root.taskfile, this
+// captured by value: even if reloadRoot later swaps root.Taskfile, this
 // snapshot keeps observing the AST that was current at snapshot time.
 type toolRootSnapshot struct {
 	workdir  string
@@ -83,8 +71,8 @@ func (s *Server) snapshotToolStateLocked() toolStateSnapshot {
 	}
 	for uri, root := range s.roots {
 		snap.roots[uri] = toolRootSnapshot{
-			workdir:  root.workdir,
-			taskfile: root.taskfile,
+			workdir:  root.Workdir,
+			taskfile: root.Taskfile,
 		}
 	}
 	return snap

--- a/internal/taskfileserver/test_helpers_test.go
+++ b/internal/taskfileserver/test_helpers_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-task/task/v3/taskfile/ast"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
 
 // testLogger returns a logger that discards all output. Tests that need
@@ -32,19 +33,19 @@ func loadServerFromFixture(t *testing.T, name string) *Server {
 	_, filename, _, _ := runtime.Caller(0)
 	dir := filepath.Join(filepath.Dir(filename), "..", "..", "testdata", name)
 
-	root, err := loadRoot(t.Context(), dir)
+	root, err := roots.Load(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("failed to load root for fixture %q: %v", name, err)
 	}
 
-	uri := dirToURI(dir)
+	uri := roots.DirToURI(dir)
 	s := New()
 	s.roots[uri] = root
 	return s
 }
 
 // onlyRoot returns the single Root from a server, or fails the test.
-func onlyRoot(t *testing.T, s *Server) *Root {
+func onlyRoot(t *testing.T, s *Server) *roots.Root {
 	t.Helper()
 	if len(s.roots) != 1 {
 		t.Fatalf("expected 1 root, got %d", len(s.roots))
@@ -128,8 +129,8 @@ func snapshotFromServer(s *Server) toolStateSnapshot {
 	}
 	for uri, root := range s.roots {
 		snap.roots[uri] = toolRootSnapshot{
-			workdir:  root.workdir,
-			taskfile: root.taskfile,
+			workdir:  root.Workdir,
+			taskfile: root.Taskfile,
 		}
 	}
 	return snap
@@ -171,11 +172,11 @@ func newTempServer(t *testing.T, taskfileContent []byte) *Server {
 // with a real *mcp.Server and initial syncTools.
 func newServerForDir(t *testing.T, dir string) *Server {
 	t.Helper()
-	root, err := loadRoot(t.Context(), dir)
+	root, err := roots.Load(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("loadRoot: %v", err)
 	}
-	uri := dirToURI(dir)
+	uri := roots.DirToURI(dir)
 	mcpSrv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
 	s := New()
 	s.toolRegistry = mcpSrv

--- a/internal/taskfileserver/tools_test.go
+++ b/internal/taskfileserver/tools_test.go
@@ -11,14 +11,15 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
 
 func TestCreateToolForTask_Basic(t *testing.T) {
 	s := loadServerFromFixture(t, "basic")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "greet")
-	tool := createToolForTask(root.taskfile, "", "greet", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "greet")
+	tool := createToolForTask(root.Taskfile, "", "greet", taskDef)
 
 	if tool.Name != "greet" {
 		t.Errorf("Name = %q, want %q", tool.Name, "greet")
@@ -37,8 +38,8 @@ func TestCreateToolForTask_NoDescription(t *testing.T) {
 	s := loadServerFromFixture(t, "no-desc")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "build")
-	tool := createToolForTask(root.taskfile, "", "build", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "build")
+	tool := createToolForTask(root.Taskfile, "", "build", taskDef)
 
 	want := "Execute task: build"
 	if tool.Description != want {
@@ -52,8 +53,8 @@ func TestCreateToolForTask_TaskVarsExcluded(t *testing.T) {
 	s := loadServerFromFixture(t, "task-vars")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "deploy")
-	tool := createToolForTask(root.taskfile, "", "deploy", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "deploy")
+	tool := createToolForTask(root.Taskfile, "", "deploy", taskDef)
 
 	props := schemaProperties(t, tool)
 	if len(props) != 0 {
@@ -68,8 +69,8 @@ func TestCreateToolForTask_GlobalVars(t *testing.T) {
 	s := loadServerFromFixture(t, "global-vars")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "info")
-	tool := createToolForTask(root.taskfile, "", "info", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "info")
+	tool := createToolForTask(root.Taskfile, "", "info", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["APP_NAME"]
@@ -93,8 +94,8 @@ func TestCreateToolForTask_GlobalVarsHonoured(t *testing.T) {
 	s := loadServerFromFixture(t, "override-vars")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "deploy")
-	tool := createToolForTask(root.taskfile, "", "deploy", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "deploy")
+	tool := createToolForTask(root.Taskfile, "", "deploy", taskDef)
 
 	props := schemaProperties(t, tool)
 	if len(props) != 1 {
@@ -122,8 +123,8 @@ func TestCreateToolForTask_GlobalVarWithoutStaticDefault(t *testing.T) {
 	s := loadServerFromFixture(t, "requires")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "release")
-	tool := createToolForTask(root.taskfile, "", "release", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "release")
+	tool := createToolForTask(root.Taskfile, "", "release", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["GIT_SHA"].(map[string]any)
@@ -142,8 +143,8 @@ func TestCreateToolForTask_RequiresVar(t *testing.T) {
 	s := loadServerFromFixture(t, "requires")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "release")
-	tool := createToolForTask(root.taskfile, "", "release", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "release")
+	tool := createToolForTask(root.Taskfile, "", "release", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["VERSION"].(map[string]any)
@@ -170,8 +171,8 @@ func TestCreateToolForTask_RequiresEnum(t *testing.T) {
 	s := loadServerFromFixture(t, "requires")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "release")
-	tool := createToolForTask(root.taskfile, "", "release", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "release")
+	tool := createToolForTask(root.Taskfile, "", "release", taskDef)
 
 	props := schemaProperties(t, tool)
 	prop, ok := props["CHANNEL"].(map[string]any)
@@ -303,8 +304,8 @@ func TestCreateToolForTask_Namespaced(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.taskName, func(t *testing.T) {
-			taskDef := lookupTask(t, root.taskfile, tt.taskName)
-			tool := createToolForTask(root.taskfile, "", tt.taskName, taskDef)
+			taskDef := lookupTask(t, root.Taskfile, tt.taskName)
+			tool := createToolForTask(root.Taskfile, "", tt.taskName, taskDef)
 
 			if tool.Name != tt.wantTool {
 				t.Errorf("Name = %q, want %q", tool.Name, tt.wantTool)
@@ -321,8 +322,8 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 	root := onlyRoot(t, s)
 
 	t.Run("single wildcard", func(t *testing.T) {
-		taskDef := lookupTask(t, root.taskfile, "start:*")
-		tool := createToolForTask(root.taskfile, "", "start:*", taskDef)
+		taskDef := lookupTask(t, root.Taskfile, "start:*")
+		tool := createToolForTask(root.Taskfile, "", "start:*", taskDef)
 
 		if tool.Name != "start" {
 			t.Errorf("Name = %q, want %q", tool.Name, "start")
@@ -354,8 +355,8 @@ func TestCreateToolForTask_Wildcard(t *testing.T) {
 	})
 
 	t.Run("double wildcard", func(t *testing.T) {
-		taskDef := lookupTask(t, root.taskfile, "deploy:*:*")
-		tool := createToolForTask(root.taskfile, "", "deploy:*:*", taskDef)
+		taskDef := lookupTask(t, root.Taskfile, "deploy:*:*")
+		tool := createToolForTask(root.Taskfile, "", "deploy:*:*", taskDef)
 
 		if tool.Name != "deploy" {
 			t.Errorf("Name = %q, want %q", tool.Name, "deploy")
@@ -386,8 +387,8 @@ func TestCreateToolForTask_LeadingDot(t *testing.T) {
 	s := loadServerFromFixture(t, "leading-dot")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "uv:.venv")
-	tool := createToolForTask(root.taskfile, "", "uv:.venv", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "uv:.venv")
+	tool := createToolForTask(root.Taskfile, "", "uv:.venv", taskDef)
 
 	if tool.Name != "uv_.venv" {
 		t.Errorf("Name = %q, want %q", tool.Name, "uv_.venv")
@@ -535,19 +536,19 @@ func TestBuildToolPlan_HandlerSelectsPrefixedRootTool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	frontendRoot, err := loadRoot(t.Context(), frontendDir)
+	frontendRoot, err := roots.Load(t.Context(), frontendDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	backendRoot, err := loadRoot(t.Context(), backendDir)
+	backendRoot, err := roots.Load(t.Context(), backendDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	s := &Server{
-		roots: map[string]*Root{
-			dirToURI(frontendDir): frontendRoot,
-			dirToURI(backendDir):  backendRoot,
+		roots: map[string]*roots.Root{
+			roots.DirToURI(frontendDir): frontendRoot,
+			roots.DirToURI(backendDir):  backendRoot,
 		},
 	}
 
@@ -680,19 +681,19 @@ func TestBuildToolPlan_ExcludesCollidingToolNamesAcrossRoots(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r1, err := loadRoot(t.Context(), dir1)
+	r1, err := roots.Load(t.Context(), dir1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	r2, err := loadRoot(t.Context(), dir2)
+	r2, err := roots.Load(t.Context(), dir2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	s := &Server{
-		roots: map[string]*Root{
-			dirToURI(dir1): r1,
-			dirToURI(dir2): r2,
+		roots: map[string]*roots.Root{
+			roots.DirToURI(dir1): r1,
+			roots.DirToURI(dir2): r2,
 		},
 	}
 
@@ -719,13 +720,13 @@ func TestBuildToolPlan_ExcludesCollidingToolNamesWithinRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := loadRoot(t.Context(), dir)
+	root, err := roots.Load(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	s := &Server{
-		roots: map[string]*Root{dirToURI(dir): root},
+		roots: map[string]*roots.Root{roots.DirToURI(dir): root},
 	}
 
 	plan := buildToolPlan(snapshotFromServer(s), testLogger())
@@ -747,13 +748,13 @@ func TestBuildToolPlan_NoTasks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := loadRoot(t.Context(), dir)
+	root, err := roots.Load(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	s := &Server{
-		roots: map[string]*Root{dirToURI(dir): root},
+		roots: map[string]*roots.Root{roots.DirToURI(dir): root},
 	}
 
 	plan := buildToolPlan(snapshotFromServer(s), testLogger())
@@ -770,8 +771,8 @@ func TestCreateToolForTask_WithPrefix(t *testing.T) {
 	s := loadServerFromFixture(t, "basic")
 	root := onlyRoot(t, s)
 
-	taskDef := lookupTask(t, root.taskfile, "greet")
-	tool := createToolForTask(root.taskfile, "myproject", "greet", taskDef)
+	taskDef := lookupTask(t, root.Taskfile, "greet")
+	tool := createToolForTask(root.Taskfile, "myproject", "greet", taskDef)
 
 	if tool.Name != "myproject_greet" {
 		t.Errorf("Name = %q, want %q", tool.Name, "myproject_greet")
@@ -784,10 +785,10 @@ func TestCreateToolForTask_WithPrefix(t *testing.T) {
 func TestCreateToolForTask_WithPrefix_EnforcesMaxLength(t *testing.T) {
 	s := loadServerFromFixture(t, "basic")
 	root := onlyRoot(t, s)
-	taskDef := lookupTask(t, root.taskfile, "greet")
+	taskDef := lookupTask(t, root.Taskfile, "greet")
 	prefix := strings.Repeat("project", 20)
 
-	tool := createToolForTask(root.taskfile, prefix, "greet", taskDef)
+	tool := createToolForTask(root.Taskfile, prefix, "greet", taskDef)
 
 	if len(tool.Name) != maxToolNameLength {
 		t.Fatalf("len(tool.Name) = %d, want %d", len(tool.Name), maxToolNameLength)
@@ -859,7 +860,7 @@ func TestBuildToolPlan_FromSnapshot(t *testing.T) {
 	snap := toolStateSnapshot{
 		generation: 42,
 		roots: map[string]toolRootSnapshot{
-			"file:///test": {workdir: root.workdir, taskfile: root.taskfile},
+			"file:///test": {workdir: root.Workdir, taskfile: root.Taskfile},
 		},
 	}
 
@@ -921,7 +922,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := loadRoot(t.Context(), dir)
+	root, err := roots.Load(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -929,9 +930,9 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 	mcpSrv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
 	tracker := newTrackingRegistry(mcpSrv)
 
-	uri := dirToURI(dir)
+	uri := roots.DirToURI(dir)
 	s := &Server{
-		roots:           map[string]*Root{uri: root},
+		roots:           map[string]*roots.Root{uri: root},
 		toolRegistry:    tracker,
 		registeredTools: make(map[string]registeredTool),
 	}
@@ -967,7 +968,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(singleTaskDir, "Taskfile.yml"), []byte("version: '3'\ntasks:\n  taskA:\n    desc: Task A\n    cmds:\n      - echo A\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	newRoot, err := loadRoot(t.Context(), singleTaskDir)
+	newRoot, err := roots.Load(t.Context(), singleTaskDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -979,7 +980,7 @@ func TestSyncTools_OrphanedToolOnConcurrentSync(t *testing.T) {
 	maps.Copy(oldTools, s.registeredTools)
 
 	// Simulate concurrent mutation while G1 is "planning".
-	newURI := dirToURI(singleTaskDir)
+	newURI := roots.DirToURI(singleTaskDir)
 	delete(s.roots, uri)
 	s.roots[newURI] = newRoot
 	s.generation++
@@ -1050,7 +1051,7 @@ func TestSnapshotToolState_IsolatedFromRootMutation(t *testing.T) {
 	s.mu.Lock()
 	snap := s.snapshotToolStateLocked()
 	// Simulate disableRootToolsLocked clearing the live root in place.
-	root.taskfile = nil
+	root.Taskfile = nil
 	s.generation++
 	s.mu.Unlock()
 

--- a/internal/taskfileserver/watch.go
+++ b/internal/taskfileserver/watch.go
@@ -178,7 +178,7 @@ func (s *Server) rootWatchState(uri string) ([]string, map[string]struct{}, bool
 		return nil, nil, false
 	}
 
-	return slices.Clone(root.watchDirs), maps.Clone(root.watchTaskfiles), true
+	return slices.Clone(root.WatchDirs), maps.Clone(root.WatchTaskfiles), true
 }
 
 // syncWatcherDirs ensures the fsnotify watcher is subscribed to the provided

--- a/internal/taskfileserver/watch_test.go
+++ b/internal/taskfileserver/watch_test.go
@@ -3,12 +3,15 @@ package taskfileserver
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rsclarke/mcp-taskfile-server/internal/roots"
 )
 
 func TestLoadRoot_WatchTaskfilesIncludesTransitive(t *testing.T) {
@@ -28,7 +31,7 @@ func TestLoadRoot_WatchTaskfilesIncludesTransitive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := loadRoot(t.Context(), dir)
+	root, err := roots.Load(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("loadRoot: %v", err)
 	}
@@ -39,7 +42,7 @@ func TestLoadRoot_WatchTaskfilesIncludesTransitive(t *testing.T) {
 		filepath.Join(deepDir, "Taskfile.yml"),
 	}
 
-	got := sortedKeys(root.watchTaskfiles)
+	got := slices.Sorted(maps.Keys(root.WatchTaskfiles))
 	if !slices.Equal(got, want) {
 		t.Fatalf("watchTaskfiles = %v, want %v", got, want)
 	}
@@ -107,11 +110,11 @@ func TestWatchTaskfiles_IgnoresUnincludedChildTaskfile(t *testing.T) {
 
 	s := newServerForDir(t, dir)
 	root := onlyRoot(t, s)
-	if _, ok := root.watchTaskfiles[filepath.Join(childDir, "Taskfile.yml")]; ok {
+	if _, ok := root.WatchTaskfiles[filepath.Join(childDir, "Taskfile.yml")]; ok {
 		t.Fatal("unexpected watch on unincluded child Taskfile")
 	}
 
-	initialTaskfile := root.taskfile
+	initialTaskfile := root.Taskfile
 	ctx := t.Context()
 
 	startTestWatchers(ctx, s)
@@ -126,7 +129,7 @@ func TestWatchTaskfiles_IgnoresUnincludedChildTaskfile(t *testing.T) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if onlyRoot(t, s).taskfile != initialTaskfile {
+	if onlyRoot(t, s).Taskfile != initialTaskfile {
 		t.Fatal("editing an unincluded child Taskfile unexpectedly reloaded the root")
 	}
 }
@@ -352,7 +355,7 @@ func TestReloadRoot_RemovesTask(t *testing.T) {
 
 	// Remove the "goodbye" task from the Taskfile.
 	updated := []byte("version: '3'\ntasks:\n  hello:\n    desc: Say hello\n    cmds:\n      - echo hello\n")
-	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).workdir, "Taskfile.yml"), updated, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).Workdir, "Taskfile.yml"), updated, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -378,7 +381,7 @@ func TestReloadRoot_RemovesAllPublicTasks(t *testing.T) {
 	}
 
 	updated := []byte("version: '3'\ntasks:\n  helper:\n    internal: true\n    cmds:\n      - echo hidden\n")
-	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).workdir, "Taskfile.yml"), updated, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).Workdir, "Taskfile.yml"), updated, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -403,7 +406,7 @@ func TestReloadRoot_UpdatesChangedTask(t *testing.T) {
 
 	// Update the task description.
 	updated := []byte("version: '3'\ntasks:\n  greet:\n    desc: Say hi there\n    cmds:\n      - echo hi there\n")
-	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).workdir, "Taskfile.yml"), updated, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(onlyRoot(t, s).Workdir, "Taskfile.yml"), updated, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -437,7 +440,7 @@ func TestWatchTaskfiles_DebounceCoalesces(t *testing.T) {
 	// Fire multiple rapid writes within the debounce window (200ms).
 	for i := range 5 {
 		content := fmt.Appendf(nil, "version: '3'\ntasks:\n  hello:\n    desc: Attempt %d\n    cmds:\n      - echo hello\n", i)
-		if err := os.WriteFile(filepath.Join(root.workdir, "Taskfile.yml"), content, 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(root.Workdir, "Taskfile.yml"), content, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -475,14 +478,14 @@ func TestWatchTaskfiles_InvalidRootTaskfileRemovesToolsUntilRestored(t *testing.
 	time.Sleep(100 * time.Millisecond)
 
 	invalid := []byte("version: '3'\ntasks:\n  hello:\n    desc: Broken hello\n    cmds:\n      - echo hello\n    vars: [\n")
-	if err := os.WriteFile(filepath.Join(root.workdir, "Taskfile.yml"), invalid, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(root.Workdir, "Taskfile.yml"), invalid, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	waitForToolCount(t, s, 0)
 
 	restored := []byte("version: '3'\ntasks:\n  hello:\n    desc: Restored hello\n    cmds:\n      - echo hello again\n")
-	if err := os.WriteFile(filepath.Join(root.workdir, "Taskfile.yml"), restored, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(root.Workdir, "Taskfile.yml"), restored, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -519,7 +522,7 @@ func TestWatchTaskfiles_DeletedRootTaskfileRemovesToolsUntilRestored(t *testing.
 
 	time.Sleep(100 * time.Millisecond)
 
-	taskfilePath := filepath.Join(root.workdir, "Taskfile.yml")
+	taskfilePath := filepath.Join(root.Workdir, "Taskfile.yml")
 	if err := os.Remove(taskfilePath); err != nil {
 		t.Fatal(err)
 	}
@@ -555,7 +558,7 @@ func TestWatchTaskfiles_DeletedRootTaskfileRemovesToolsUntilRestored(t *testing.
 
 func TestReconcileRoots_MissingInitialTaskfileLoadsWhenCreatedLater(t *testing.T) {
 	dir := t.TempDir()
-	uri := dirToURI(dir)
+	uri := roots.DirToURI(dir)
 	s := New()
 	s.toolRegistry = noopRegistry{}
 	defer s.Shutdown()
@@ -569,14 +572,14 @@ func TestReconcileRoots_MissingInitialTaskfileLoadsWhenCreatedLater(t *testing.T
 	s.restartWatchers(t.Context())
 
 	root := onlyRoot(t, s)
-	if root.taskfile != nil {
+	if root.Taskfile != nil {
 		t.Fatal("expected root to be tracked without a loaded Taskfile")
 	}
-	if !slices.Equal(root.watchDirs, []string{dir}) {
-		t.Fatalf("watchDirs = %v, want [%s]", root.watchDirs, dir)
+	if !slices.Equal(root.WatchDirs, []string{dir}) {
+		t.Fatalf("watchDirs = %v, want [%s]", root.WatchDirs, dir)
 	}
 	for _, filename := range []string{"Taskfile.yml", "Taskfile.yaml", "Taskfile.dist.yml", "Taskfile.dist.yaml"} {
-		if _, ok := root.watchTaskfiles[filepath.Join(dir, filename)]; !ok {
+		if _, ok := root.WatchTaskfiles[filepath.Join(dir, filename)]; !ok {
 			t.Fatalf("expected %s to be watched", filename)
 		}
 	}
@@ -605,7 +608,7 @@ func TestReconcileRoots_MissingInitialTaskfileLoadsWhenCreatedLater(t *testing.T
 			tool, ok := s.registeredTools["hello"]
 			loadedRoot := s.roots[uri]
 			s.mu.Unlock()
-			if ok && tool.Description == "Added after startup" && loadedRoot != nil && loadedRoot.taskfile != nil {
+			if ok && tool.Description == "Added after startup" && loadedRoot != nil && loadedRoot.Taskfile != nil {
 				return
 			}
 		}


### PR DESCRIPTION
Phase B of #80: move the per-root domain (Root value type, URI canonicalisation, root loading, Taskfile graph parsing) out of `internal/taskfileserver` into a new `internal/roots` package. The new package has no MCP SDK dependency, so its surface stays focused on filesystem and Taskfile concerns and is reusable from any future server-side glue.

- Introduce `internal/roots` with `Root` (read-only public fields), `DirToURI`, `CanonicalRootURI`, `Load`, `NewUnloaded`, and `Build`
- Keep `unloadRoot`, `disableRootToolsLocked`, and `reloadRoot` as Server methods in `internal/taskfileserver`, now operating on `*roots.Root`
- Move URI, load, and Taskfile-graph tests into `internal/roots`; `TestSanitizeRootPrefix` moves to a new `internal/taskfileserver/naming_test.go`
- No behaviour change; integration tests (the characterization gate) and `task ci` remain green

Refs #80