### PR TITLE
refactor: rename internal/taskfileserver to internal/server

### DIFF
--- a/internal/server/doc.go
+++ b/internal/server/doc.go
@@ -1,0 +1,2 @@
+// Package server implements the Taskfile-backed MCP server.
+package server

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"context"

--- a/internal/server/logging_mcp_test.go
+++ b/internal/server/logging_mcp_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"bytes"

--- a/internal/server/logging_test.go
+++ b/internal/server/logging_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"bytes"

--- a/internal/server/reconcile_test.go
+++ b/internal/server/reconcile_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"os"

--- a/internal/server/roots.go
+++ b/internal/server/roots.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"context"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"context"

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"log/slog"

--- a/internal/server/test_helpers_test.go
+++ b/internal/server/test_helpers_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"context"

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"maps"

--- a/internal/server/tools_test.go
+++ b/internal/server/tools_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"maps"

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"context"

--- a/internal/server/watch_test.go
+++ b/internal/server/watch_test.go
@@ -1,4 +1,4 @@
-package taskfileserver
+package server
 
 import (
 	"context"

--- a/internal/taskfileserver/doc.go
+++ b/internal/taskfileserver/doc.go
@@ -1,2 +1,0 @@
-// Package taskfileserver implements the Taskfile-backed MCP server.
-package taskfileserver

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rsclarke/mcp-taskfile-server/internal/logging"
-	"github.com/rsclarke/mcp-taskfile-server/internal/taskfileserver"
+	"github.com/rsclarke/mcp-taskfile-server/internal/server"
 )
 
 // Build-time variables set via -ldflags.
@@ -18,7 +18,7 @@ var (
 )
 
 func run() error {
-	taskfileServer := taskfileserver.New()
+	taskfileServer := server.New()
 	taskfileServer.SetLogger(logging.NewLogger(serverName, serverVersion))
 	defer taskfileServer.Shutdown()
 


### PR DESCRIPTION
Final phase of the multi-PR refactor tracked in #80. Renames `internal/taskfileserver` to `internal/server` as a pure `git mv` with package declaration and import path updates only. No behaviour change.

## Changes
- `git mv internal/taskfileserver internal/server` for all files (history preserved).
- Update `package taskfileserver` → `package server` across all moved `.go` files.
- Update package doc comment in `internal/server/doc.go`.
- Update import path and call site in `main.go` (`taskfileserver.New()` → `server.New()`). Public surface (`New`, `SetLogger`, `SetToolRegistry`, `HandleInitialized`, `HandleRootsChanged`, `Shutdown`) unchanged.

## Verification
- `task ci` (lint + tests) passes locally.
- No remaining `taskfileserver` references outside `.git` history and the existing build artefact.

Closes #80.