### PR TITLE
refactor(server): inline test-only restartWatchers as test helper

### DIFF
--- a/internal/server/test_helpers_test.go
+++ b/internal/server/test_helpers_test.go
@@ -78,13 +78,25 @@ func toolNames[V any](tools map[string]V) []string {
 	return names
 }
 
-// snapshotRoots returns a slice of canonical root URIs.
+// snapshotRoots returns a slice of canonical root URIs. It acquires
+// s.mu so it is safe to call while watcher goroutines are reading
+// s.roots concurrently.
 func snapshotRoots(s *Server) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	uris := make([]string, 0, len(s.roots))
 	for uri := range s.roots {
 		uris = append(uris, uri)
 	}
 	return uris
+}
+
+// reconcileWatchersForTest drives watch.Manager.Reconcile against the
+// server's currently loaded roots. Production code uses the diff-based
+// s.watchers.Apply path driven by initializeRoots/replaceRoots; tests
+// that populate s.roots directly use this full-set entry point instead.
+func reconcileWatchersForTest(ctx context.Context, s *Server) {
+	s.watchers.Reconcile(ctx, snapshotRoots(s))
 }
 
 // startTestWatchers spawns a per-root watcher goroutine for every loaded

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"maps"
 	"slices"
 )
@@ -25,24 +24,4 @@ func (s *Server) RootWatchState(uri string) ([]string, map[string]struct{}, bool
 // future calls into the watcher manager become no-ops.
 func (s *Server) Shutdown() {
 	s.watchers.Shutdown()
-}
-
-// restartWatchers reconciles the watcher set so that one watcher is
-// running per current root. It is a thin wrapper around the per-root
-// watcher manager: existing watchers are left running, watchers for
-// removed roots are cancelled, and watchers for newly added roots are
-// spawned.
-//
-// The provided ctx is detached via context.WithoutCancel inside the
-// manager, because callers may pass request-scoped contexts that are
-// cancelled after the handler returns; watchers must outlive the request.
-func (s *Server) restartWatchers(ctx context.Context) {
-	s.mu.Lock()
-	rootURIs := make([]string, 0, len(s.roots))
-	for uri := range s.roots {
-		rootURIs = append(rootURIs, uri)
-	}
-	s.mu.Unlock()
-
-	s.watchers.Reconcile(ctx, rootURIs)
 }

--- a/internal/server/watch_test.go
+++ b/internal/server/watch_test.go
@@ -300,7 +300,7 @@ func TestServerShutdown_StopsActiveWatchersAndIsIdempotent(t *testing.T) {
 	}
 
 	s := newServerForDir(t, dir)
-	s.restartWatchers(context.Background())
+	reconcileWatchersForTest(context.Background(), s)
 
 	if got := s.watchers.Active(); got == 0 {
 		t.Fatalf("expected at least one active watcher, got %d", got)
@@ -335,10 +335,10 @@ func TestServerShutdown_StopsActiveWatchersAndIsIdempotent(t *testing.T) {
 		t.Fatal("second Shutdown call blocked")
 	}
 
-	s.restartWatchers(context.Background())
+	reconcileWatchersForTest(context.Background(), s)
 
 	if got := s.watchers.Active(); got != 0 {
-		t.Fatalf("restartWatchers should be a no-op after Shutdown, got %d active watchers", got)
+		t.Fatalf("Reconcile should be a no-op after Shutdown, got %d active watchers", got)
 	}
 }
 
@@ -570,7 +570,7 @@ func TestReconcileRoots_MissingInitialTaskfileLoadsWhenCreatedLater(t *testing.T
 	if err := s.syncTools(); err != nil {
 		t.Fatalf("syncTools: %v", err)
 	}
-	s.restartWatchers(t.Context())
+	reconcileWatchersForTest(t.Context(), s)
 
 	root := onlyRoot(t, s)
 	if root.Taskfile != nil {


### PR DESCRIPTION
Post-#80 tidy-up: `restartWatchers` in `internal/server/watch.go` was test-only — production code drives the watcher set through the diff-based `s.watchers.Apply` path returned by `initializeRoots`/`replaceRoots`. The "restart" name was also misleading: the function called `s.watchers.Reconcile` against the current root set, neither stopping nor starting watchers explicitly. Moving it into the test helpers makes the test-only intent explicit and removes a production surface that has no production callers.

- Drop `restartWatchers` and the now-unused `context` import from `internal/server/watch.go`.
- Add `reconcileWatchersForTest` to `internal/server/test_helpers_test.go` with a doc comment explaining why tests use the full-set `Reconcile` entry point instead of `Apply`.
- Lock `snapshotRoots` with `s.mu` so it is safe under concurrent watcher reads.
- Update the three call sites in `internal/server/watch_test.go`; the post-Shutdown idempotency assertion now references `Reconcile` instead of the dead `restartWatchers` name.

No behaviour change. `task ci` is green.