### PR TITLE
fix(lint): drop unused gosec nolint on context.WithCancel

### DIFF
--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -127,9 +127,7 @@ func (m *Manager) Apply(baseCtx context.Context, added, removed []string) {
 		if _, ok := m.watchers[uri]; ok {
 			continue
 		}
-		// cancel is stored in rootWatcher.cancel and invoked from
-		// Apply (on removal) or Shutdown; gosec cannot trace this.
-		ctx, cancel := context.WithCancel(parent) //nolint:gosec // cancel is held in rootWatcher.cancel
+		ctx, cancel := context.WithCancel(parent)
 		w := &rootWatcher{cancel: cancel, done: make(chan struct{})}
 		m.watchers[uri] = w
 		spawning = append(spawning, spawn{uri: uri, ctx: ctx, w: w})


### PR DESCRIPTION
A recent CI failure (and local `task ci`) started reporting `nolintlint` for the `//nolint:gosec` directive in `internal/watch/watch.go`. The suppression became stale after golangci-lint v2.12.0 bumped `securego/gosec` from v2.25.0 to v2.26.1, which includes [securego/gosec#1626](https://github.com/securego/gosec/pull/1626) — a fix to the taint analyzer's `*ssa.Phi` handling. The analyzer now correctly traces the `cancel` callback held in `rootWatcher.cancel` to its invocation sites, so gosec no longer flags the `context.WithCancel` call.

- Remove the now-unused `//nolint:gosec` directive (and its preamble comment) on the `context.WithCancel` call in `internal/watch/watch.go`.
