### PR TITLE
chore(actions): audit and harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +17,5 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,21 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    name: Test
+    name: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: Run zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Required for zizmor-action to upload SARIF to GitHub code scanning.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,6 +16,16 @@ tasks:
     cmds:
       - golangci-lint run --fix
 
+  zizmor:
+    desc: Audit GitHub Actions with zizmor
+    cmds:
+      - zizmor --strict-collection .
+
+  zizmor:fix:
+    desc: Run zizmor safe fixes
+    cmds:
+      - zizmor --fix=safe --strict-collection .
+
   test:
     desc: Run tests
     cmds:


### PR DESCRIPTION
This audits and hardens the repository's GitHub Actions surface with zizmor. It fixes existing workflow and Dependabot findings, adds ongoing zizmor auditing, and exposes local Taskfile tasks for running the audit and safe fixes.

- Harden CI workflow permissions, checkout credential handling, concurrency, and job naming.
- Add Dependabot update cooldowns for Go modules and GitHub Actions.
- Add a pinned zizmor workflow that uploads SARIF to GitHub code scanning with documented permissions.
- Add `task zizmor` and `task zizmor:fix` for local auditing and safe autofixes.

Validation:
- `zizmor --strict-collection .`
- `zizmor --persona=auditor .`
- `task --list`
- `task zizmor`
- `task zizmor:fix`
